### PR TITLE
Migrate GH actions to v3.2 branch

### DIFF
--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -1,0 +1,53 @@
+name: Corelibrary Build & Publish
+
+on:
+  push:
+    branches:
+      - "v[0-9]+.[0-9]+"
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 2.1.807
+      - name: Version
+        run: |
+          BRANCH=${GITHUB_REF#refs/*/}
+          if [[ $BRANCH =~ ^v[0-9]+.[0-9]+$ ]]
+          then
+            BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 500 )) # compensate for old jenkins CI
+            VERSION="${BRANCH#v}.$BUILD_NUMBER"
+            IS_MASTER_BUILD=1
+          else
+            VERSION="0.0.0"
+            IS_MASTER_BUILD=0
+          fi
+          echo Building on "$BRANCH"
+          echo Building version: "$VERSION"
+
+          echo "::set-env name=VERSION::${VERSION}"
+          echo "::set-env name=IS_MASTER_BUILD::${IS_MASTER_BUILD}"
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+        env:
+          GIT_COMMIT: ${{ github.sha }}
+      - name: Test
+        run: dotnet msbuild /t:RunTests /p:Configuration=Release
+        working-directory: test
+      - name: Pack
+        if: env.IS_MASTER_BUILD == '1'
+        run: dotnet pack --no-build -c Release -o $PWD/packed
+      - name: Publish
+        if: env.IS_MASTER_BUILD == '1'
+        run: find packed/ -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
It's just the copied actions workflow with substituted dotnet version. The license and other information are already there. Hope it's everything we need :stuck_out_tongue: 