### PR TITLE
Fix content root path in integration test

### DIFF
--- a/test/Testing/LeanCode.IntegrationTestHelpers.Tests/LeanCode.IntegrationTestHelpers.Tests.csproj
+++ b/test/Testing/LeanCode.IntegrationTestHelpers.Tests/LeanCode.IntegrationTestHelpers.Tests.csproj
@@ -35,14 +35,4 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- You can select between this attribute or ENV variable set in Dockerfile -->
-    <WebApplicationFactoryContentRootAttribute
-      Include="LeanCode.IntegrationTestHelpers.Tests"
-      AssemblyName="LeanCode.IntegrationTestHelpers.Tests"
-      ContentRootPath="$(MSBuildProjectDirectory)"
-      ContentRootTest="LeanCode.IntegrationTestHelpers.Tests.csproj"
-      Priority="-1" />
-  </ItemGroup>
-
 </Project>

--- a/test/Testing/LeanCode.IntegrationTestHelpers.Tests/docker/Dockerfile
+++ b/test/Testing/LeanCode.IntegrationTestHelpers.Tests/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM leancode.azurecr.io/dotnet:3.1
 
-WORKDIR /app
+WORKDIR /app/code
 
 COPY . .
 
 RUN dotnet restore
 
-WORKDIR /app/test/Testing/LeanCode.IntegrationTestHelpers.Tests
+WORKDIR /app/code/test/Testing/LeanCode.IntegrationTestHelpers.Tests
 ENV ASPNETCORE_TEST_CONTENTROOT_LEANCODE_INTEGRATIONTESTHELPERS_TESTS=/app/code/test/Testing/LeanCode.IntegrationTestHelpers.Tests
 RUN dotnet build --no-restore
 


### PR DESCRIPTION
One of the two integration tests was failing due setting wrong content root path in the environment variable.