### PR TITLE
Add strongly typed ids

### DIFF
--- a/src/Domain/LeanCode.DomainModels.EF/IdConverter.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/IdConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using LeanCode.DomainModels.Model;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace LeanCode.DomainModels.EF
+{
+    public class IdConverter<T> : ValueConverter<Id<T>, Guid>
+        where T : class, IIdentifiable<Id<T>>
+    {
+        public static readonly IdConverter<T> Instance = new IdConverter<T>();
+
+        private IdConverter()
+            : base(
+                d => d.Value,
+                d => new Id<T>(d),
+                mappingHints: null)
+        { }
+    }
+
+    public class IIdConverter<T> : ValueConverter<IId<T>, int>
+        where T : class, IIdentifiable<IId<T>>
+    {
+        public static readonly IIdConverter<T> Instance = new IIdConverter<T>();
+
+        private IIdConverter()
+            : base(
+                d => d.Value,
+                d => new IId<T>(d),
+                mappingHints: null)
+        { }
+    }
+}

--- a/src/Domain/LeanCode.DomainModels.EF/PropertyBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/PropertyBuilderExtensions.cs
@@ -1,0 +1,20 @@
+using LeanCode.DomainModels.Model;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LeanCode.DomainModels.EF
+{
+    public static class PropertyBuilderExtensions
+    {
+        public static PropertyBuilder<Id<T>> IsTypedId<T>(this PropertyBuilder<Id<T>> builder)
+            where T : class, IIdentifiable<Id<T>>
+        {
+            return builder.HasConversion(IdConverter<T>.Instance);
+        }
+
+        public static PropertyBuilder<IId<T>> IsTypedId<T>(this PropertyBuilder<IId<T>> builder)
+            where T : class, IIdentifiable<IId<T>>
+        {
+            return builder.HasConversion(IIdConverter<T>.Instance);
+        }
+    }
+}

--- a/src/Domain/LeanCode.DomainModels/LeanCode.DomainModels.csproj
+++ b/src/Domain/LeanCode.DomainModels/LeanCode.DomainModels.csproj
@@ -1,6 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-        <ProjectReference Include="../LeanCode.IdentityProvider/LeanCode.IdentityProvider.csproj" />
-    </ItemGroup>
 </Project>

--- a/src/Domain/LeanCode.DomainModels/LeanCode.DomainModels.csproj
+++ b/src/Domain/LeanCode.DomainModels/LeanCode.DomainModels.csproj
@@ -1,3 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <ItemGroup>
+        <ProjectReference Include="../LeanCode.IdentityProvider/LeanCode.IdentityProvider.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/Domain/LeanCode.DomainModels/Model/Id.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/Id.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using LeanCode.DomainModels.Serialization;
-using LeanCode.IdentityProvider;
 
 namespace LeanCode.DomainModels.Model
 {
@@ -19,7 +18,7 @@ namespace LeanCode.DomainModels.Model
             Value = value;
         }
 
-        public static Id<TEntity> New() => new Id<TEntity>(Identity.NewId());
+        public static Id<TEntity> New() => new Id<TEntity>(Guid.NewGuid());
         public static Id<TEntity> From(Guid id) => new Id<TEntity>(id);
         public static Id<TEntity>? From(Guid? id) => id is Guid v ? new Id<TEntity>(v) : (Id<TEntity>?)null;
 

--- a/src/Domain/LeanCode.DomainModels/Model/Id.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/Id.cs
@@ -10,6 +10,8 @@ namespace LeanCode.DomainModels.Model
     public readonly struct Id<TEntity> : IEquatable<Id<TEntity>>, IComparable<Id<TEntity>>
         where TEntity : class, IIdentifiable<Id<TEntity>>
     {
+        public static readonly Id<TEntity> Empty = default;
+
         public Guid Value { get; }
 
         public Id(Guid value)
@@ -38,7 +40,7 @@ namespace LeanCode.DomainModels.Model
     public readonly struct IId<TEntity> : IEquatable<IId<TEntity>>, IComparable<IId<TEntity>>
         where TEntity : class, IIdentifiable<IId<TEntity>>
     {
-        public static readonly IId<TEntity> EmptyValue = IId<TEntity>.From(0);
+        public static readonly IId<TEntity> Empty = default;
 
         public int Value { get; }
 

--- a/src/Domain/LeanCode.DomainModels/Model/Id.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/Id.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using LeanCode.DomainModels.Serialization;
+using LeanCode.IdentityProvider;
+
+namespace LeanCode.DomainModels.Model
+{
+    [DebuggerDisplay("{Value}")]
+    [TypedIdConverter]
+    public readonly struct Id<TEntity> : IEquatable<Id<TEntity>>, IComparable<Id<TEntity>>
+        where TEntity : class, IIdentifiable<Id<TEntity>>
+    {
+        public Guid Value { get; }
+
+        public Id(Guid value)
+        {
+            Value = value;
+        }
+
+        public static Id<TEntity> New() => new Id<TEntity>(Identity.NewId());
+        public static Id<TEntity> From(Guid id) => new Id<TEntity>(id);
+        public static Id<TEntity>? From(Guid? id) => id is Guid v ? new Id<TEntity>(v) : (Id<TEntity>?)null;
+
+        public bool Equals(Id<TEntity> other) => Value.Equals(other.Value);
+        public int CompareTo(Id<TEntity> other) => Value.CompareTo(other.Value);
+        public override bool Equals(object? obj) => obj is Id<TEntity> id && Value.Equals(id.Value);
+        public override int GetHashCode() => HashCode.Combine(Value);
+        public override string? ToString() => Value.ToString();
+
+        public static bool operator ==(Id<TEntity> left, Id<TEntity> right) => left.Equals(right);
+        public static bool operator !=(Id<TEntity> left, Id<TEntity> right) => !left.Equals(right);
+        public static implicit operator Guid(Id<TEntity> id) => id.Value;
+        public static explicit operator Id<TEntity>(Guid id) => new Id<TEntity>(id);
+    }
+
+    [DebuggerDisplay("{Value}")]
+    [TypedIdConverter]
+    public readonly struct IId<TEntity> : IEquatable<IId<TEntity>>, IComparable<IId<TEntity>>
+        where TEntity : class, IIdentifiable<IId<TEntity>>
+    {
+        public static readonly IId<TEntity> EmptyValue = IId<TEntity>.From(0);
+
+        public int Value { get; }
+
+        public IId(int value)
+        {
+            Value = value;
+        }
+
+        public static IId<TEntity> From(int id) => new IId<TEntity>(id);
+        public static IId<TEntity>? From(int? id) => id is int v ? new IId<TEntity>(v) : (IId<TEntity>?)null;
+
+        public bool Equals(IId<TEntity> other) => Value.Equals(other.Value);
+        public int CompareTo(IId<TEntity> other) => Value.CompareTo(other.Value);
+        public override bool Equals(object? obj) => obj is IId<TEntity> id && Value.Equals(id.Value);
+        public override int GetHashCode() => HashCode.Combine(Value);
+        public override string? ToString() => Value.ToString();
+
+        public static bool operator ==(IId<TEntity> left, IId<TEntity> right) => left.Equals(right);
+        public static bool operator !=(IId<TEntity> left, IId<TEntity> right) => !left.Equals(right);
+        public static implicit operator int(IId<TEntity> id) => id.Value;
+        public static explicit operator IId<TEntity>(int id) => new IId<TEntity>(id);
+    }
+}

--- a/src/Domain/LeanCode.DomainModels/Serialization/TypedIdConverterAttribute.cs
+++ b/src/Domain/LeanCode.DomainModels/Serialization/TypedIdConverterAttribute.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LeanCode.DomainModels.Model;
+
+namespace LeanCode.DomainModels.Serialization
+{
+    internal class TypedIdConverterAttribute : JsonConverterAttribute
+    {
+        private static readonly Dictionary<Type, Type> Converters = new Dictionary<Type, Type>
+        {
+            [typeof(Id<>)] = typeof(IdConverter<>),
+            [typeof(IId<>)] = typeof(IIdConverter<>),
+        };
+
+        public override JsonConverter CreateConverter(Type typeToConvert)
+        {
+            if (!typeToConvert.IsGenericType
+                || !Converters.TryGetValue(typeToConvert.GetGenericTypeDefinition(), out var converterGenericType))
+            {
+                throw new InvalidOperationException($"{nameof(TypedIdConverterAttribute)} can only by used for strongly typed id types");
+            }
+
+            var entityType = typeToConvert.GetGenericArguments()[0];
+            var converterType = converterGenericType.MakeGenericType(entityType);
+            var converter = Activator.CreateInstance(converterType);
+            return (JsonConverter)converter!;
+        }
+
+        private class IdConverter<T> : JsonConverter<Id<T>>
+            where T : class, IIdentifiable<Id<T>>
+        {
+            public override Id<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TryGetGuid(out var id))
+                {
+                    return new Id<T>(id);
+                }
+
+                throw new JsonException($"Could not deserialize {typeToConvert.Name}");
+            }
+
+            public override void Write(Utf8JsonWriter writer, Id<T> value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.Value);
+            }
+        }
+
+        private class IIdConverter<T> : JsonConverter<IId<T>>
+            where T : class, IIdentifiable<IId<T>>
+        {
+            public override IId<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TryGetInt32(out var id))
+                {
+                    return new IId<T>(id);
+                }
+
+                throw new JsonException($"Could not deserialize {typeToConvert.Name}");
+            }
+
+            public override void Write(Utf8JsonWriter writer, IId<T> value, JsonSerializerOptions options)
+            {
+                writer.WriteNumberValue(value.Value);
+            }
+        }
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.Tests/TypedIdSerializationTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/TypedIdSerializationTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text.Json;
+using LeanCode.DomainModels.Model;
+using Xunit;
+
+namespace LeanCode.DomainModels.Tests
+{
+    public class TypedIdSerializationTests
+    {
+        private class Entity : IIdentifiable<Id<Entity>>
+        {
+            public Id<Entity> Id { get; set; }
+        }
+
+        private class IntEntity : IIdentifiable<IId<IntEntity>>
+        {
+            public IId<IntEntity> Id { get; set; }
+        }
+
+        [Fact]
+        public void Serializes_and_deserializes_non_nullable_id()
+        {
+            var idString = "00000000-0000-0000-0000-000000000001";
+            var id = Id<Entity>.From(Guid.Parse(idString));
+
+            var json = JsonSerializer.Serialize(id);
+            var deserialized = JsonSerializer.Deserialize<Id<Entity>>(json);
+
+            Assert.Equal('"' + idString + '"', json);
+            Assert.Equal(id, deserialized);
+        }
+
+        [Fact]
+        public void Serializes_and_deserializes_nullable_id()
+        {
+            var idString = "00000000-0000-0000-0000-000000000001";
+            Id<Entity>? id = Id<Entity>.From(Guid.Parse(idString));
+
+            var json = JsonSerializer.Serialize(id);
+            var deserialized = JsonSerializer.Deserialize<Id<Entity>?>(json);
+
+            Assert.Equal('"' + idString + '"', json);
+            Assert.Equal(id, deserialized);
+        }
+
+        [Fact]
+        public void Serializes_and_deserializes_null_id()
+        {
+            Id<Entity>? id = null;
+
+            var json = JsonSerializer.Serialize(id);
+            var deserialized = JsonSerializer.Deserialize<Id<Entity>?>(json);
+
+            Assert.Equal("null", json);
+            Assert.Equal(id, deserialized);
+        }
+
+        [Fact]
+        public void Serializes_and_deserializes_int_id()
+        {
+            var id = IId<IntEntity>.From(7);
+
+            var json = JsonSerializer.Serialize(id);
+            var deserialized = JsonSerializer.Deserialize<IId<IntEntity>>(json);
+
+            Assert.Equal("7", json);
+            Assert.Equal(id, deserialized);
+        }
+    }
+}


### PR DESCRIPTION
Most of this is a just compilation from other projects, with the exception of json serialization.

An open question, since we add this to corelib, do we want to also add `SId` with a string backing field?