### PR TITLE
Set culture info directly when sending email

### DIFF
--- a/src/Infrastructure/LeanCode.SendGrid/SendGridLocalizedRazorMessage.cs
+++ b/src/Infrastructure/LeanCode.SendGrid/SendGridLocalizedRazorMessage.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Newtonsoft.Json;
@@ -16,6 +15,11 @@ namespace LeanCode.SendGrid
         public SendGridLocalizedRazorMessage(string cultureName)
         {
             Culture = CultureInfo.GetCultureInfo(cultureName);
+        }
+
+        public SendGridLocalizedRazorMessage(CultureInfo cultureInfo)
+        {
+            Culture = cultureInfo.IsReadOnly ? cultureInfo : CultureInfo.ReadOnly(cultureInfo);
         }
 
         public void SetGlobalSubject(string subjectKey, object[]? subjectFormatArgs)


### PR DESCRIPTION
Handy overload in case you have the `CultureInfo` already.