### PR TITLE
Publish builds as artifacts

### DIFF
--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -3,7 +3,7 @@ name: Corelibrary Build & Publish
 on:
   push:
     branches:
-      - 'v[0-9].[0-9]'
+      - 'v[0-9]+.[0-9]+'
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -54,6 +54,7 @@ jobs:
         echo "::set-output name=publish_nuget::${PUBLISH_NUGET}"
         echo "::set-output name=artifacts_name::${ARTIFACTS_NAME}"      
   build:
+    name: Build
     runs-on: ubuntu-18.04
     needs: [prepare]
     env:

--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -2,38 +2,70 @@ name: Corelibrary Build & Publish
 
 on:
   push:
-    branches: 
-      - 'v[0-9]+.[0-9]+'
+    branches:
+      - 'v[0-9].[0-9]'
   pull_request:
+  workflow_dispatch:
 jobs:
-  build:
+  prepare:
+    name: Prepare & Version
     runs-on: ubuntu-18.04
-    env:
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      publish_artifacts: ${{ steps.version.outputs.publish_artifacts }}
+      publish_nuget: ${{ steps.version.outputs.publish_nuget }}
+      artifacts_name: ${{ steps.version.outputs.artifacts_name }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.202
     - name: Version
+      id: version
       run: |
         BRANCH=${GITHUB_REF#refs/*/}
         if [[ $BRANCH =~ ^v[0-9]+.[0-9]+$ ]]
         then
           BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 500 )) # compensate for old jenkins CI
           VERSION="${BRANCH#v}.$BUILD_NUMBER"
-          IS_MASTER_BUILD=1
+          PUBLISH_ARTIFACTS=1
+          ARTIFACTS_NAME="LeanCode.CoreLibrary.$VERSION.zip"
         else
           VERSION="0.0.0"
-          IS_MASTER_BUILD=0
+          PUBLISH_ARTIFACTS=0
+          ARTIFACTS_NAME="<none>"
         fi
-        echo Building on "$BRANCH"
-        echo Building version: "$VERSION"
+        echo $BRANCH
+        echo $VERSION
+        echo "Artifacts will be saved as $ARTIFACTS_NAME" 
         
-        echo "::set-env name=VERSION::${VERSION}"
-        echo "::set-env name=IS_MASTER_BUILD::${IS_MASTER_BUILD}"
+        if [[ $GITHUB_EVENT_NAME == 'workflow_dispatch' ]]
+        then
+          echo "Packages will be published to NuGet"
+          PUBLISH_NUGET=1
+        else
+          PUBLISH_NUGET=0
+        fi
+        
+        if [ $PUBLISH_ARTIFACTS == 0 ] && [ $PUBLISH_NUGET == 1 ]
+        then
+          echo "Only vX.Y branches can be published to NuGet, failing"
+          exit 1
+        fi 
+                
+        echo "::set-output name=version::${VERSION}"
+        echo "::set-output name=publish_artifacts::${PUBLISH_ARTIFACTS}"
+        echo "::set-output name=publish_nuget::${PUBLISH_NUGET}"
+        echo "::set-output name=artifacts_name::${ARTIFACTS_NAME}"      
+  build:
+    runs-on: ubuntu-18.04
+    needs: [prepare]
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.202
     - name: Restore
       run: dotnet restore
     - name: Build
@@ -44,10 +76,14 @@ jobs:
       run: dotnet msbuild /t:RunTests /p:Configuration=Release
       working-directory: test
     - name: Pack
-      if: env.IS_MASTER_BUILD == '1'
-      run: dotnet pack --no-build -c Release -o $PWD/packed
-    # - name: Publish
-    #   if: env.IS_MASTER_BUILD == '1'
-    #   run: find packed/ -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
-    #   env:
-    #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      if: ${{ needs.prepare.outputs.publish_artifacts == '1' }}
+      env:
+        ZIP: ${{ needs.prepare.outputs.artifacts_name }} 
+      run: |
+        dotnet pack --no-build -c Release -o $PWD/packed
+        zip $ZIP $PWD/packed/*.nupgk
+    - name: Publish artifacts
+      if: ${{ needs.prepare.outputs.publish_artifacts == '1' }}
+      uses: actions/upload-artifact@v1
+      with:
+        path: ${{ needs.prepare.outputs.artifacts_name }}

--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -82,9 +82,31 @@ jobs:
         ZIP: ${{ needs.prepare.outputs.artifacts_name }} 
       run: |
         dotnet pack --no-build -c Release -o $PWD/packed
-        zip $ZIP $PWD/packed/*.nupgk
+        zip -j $ZIP $PWD/packed/*.nupgk
     - name: Publish artifacts
       if: ${{ needs.prepare.outputs.publish_artifacts == '1' }}
       uses: actions/upload-artifact@v1
       with:
         path: ${{ needs.prepare.outputs.artifacts_name }}
+  publish:
+    runs-on: ubuntu-18.04
+    name: Publish to NuGet
+    needs: [ prepare, build ]
+    if: ${{ needs.prepare.outputs.publish_nugets == '1' }}
+    steps:
+    - name: Fetch build
+      uses: actions/download-artifact@v1
+      with: 
+        name: ${{ needs.prepare.outputs.artifacts_name }}
+    - name: Create release
+      uses: actions/create-release@v1
+      with:
+        tag_name: v${{ needs.prepare.outputs.version }}
+        release_name: Release v${{ needs.prepare.outputs.version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ZIP: ${{ needs.prepare.outputs.artifacts_name }}
+    - name: Push to NuGet
+      run: |
+        unzip $ZIP
+        dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' *.nupkg


### PR DESCRIPTION
First step of reworking Github Actions.
The new flow will be:
1. Every build on main branches will publish packages as build artifacts only (as a plain zipfile)
2. Only manually selected builds will be pushed to NuGet - it will be done via manual action dispatch.

Initially I wanted to make a separate workflows for building and publishing, but it has a drawback, you cannot share run numbers with other workflows, so I unified it for versioning consistency. So far, nothing is published to nuget, I have to create another job which would fetch the zip, tag the commit and push it to nuget.

