### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -1,53 +1,115 @@
-name: Corelibrary Build & Publish 
+name: Corelibrary Build & Publish
 
 on:
   push:
-    branches: 
-      - 'v[0-9]+.[0-9]+'
+    branches:
+      - "v[0-9]+.[0-9]+"
   pull_request:
+  workflow_dispatch:
 jobs:
-  build:
+  prepare:
+    name: Prepare & Version
     runs-on: ubuntu-18.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      publish_artifacts: ${{ steps.version.outputs.publish_artifacts }}
+      publish_nuget: ${{ steps.version.outputs.publish_nuget }}
+      artifacts_name: ${{ steps.version.outputs.artifacts_name }}
+    steps:
+      - name: Version
+        id: version
+        run: |
+          BRANCH=${GITHUB_REF#refs/*/}
+          if [[ $BRANCH =~ ^v[0-9]+.[0-9]+$ ]]
+          then
+            BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 500 )) # compensate for old jenkins CI
+            VERSION="${BRANCH#v}.$BUILD_NUMBER"
+            PUBLISH_ARTIFACTS=1
+            ARTIFACTS_NAME="LeanCode.CoreLibrary.$VERSION.zip"
+          else
+            VERSION="0.0.0"
+            PUBLISH_ARTIFACTS=0
+            ARTIFACTS_NAME="<none>"
+          fi
+          echo Building on "$BRANCH"
+          echo Building version: "$VERSION"
+          echo "Artifacts will be saved as $ARTIFACTS_NAME"
+
+          if [[ $GITHUB_EVENT_NAME == 'workflow_dispatch' ]]
+          then
+            echo "Packages will be published to NuGet"
+            PUBLISH_NUGET=1
+          else
+            PUBLISH_NUGET=0
+          fi
+
+          if [[ $PUBLISH_ARTIFACTS == 0 && $PUBLISH_NUGET == 1 ]]
+          then
+            echo "Only vX.Y branches can be published to NuGet, failing"
+            exit 1
+          fi
+
+          echo "::set-output name=version::${VERSION}"
+          echo "::set-output name=publish_artifacts::${PUBLISH_ARTIFACTS}"
+          echo "::set-output name=publish_nuget::${PUBLISH_NUGET}"
+          echo "::set-output name=artifacts_name::${ARTIFACTS_NAME}"
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    needs: [prepare]
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.202
-    - name: Version
-      run: |
-        BRANCH=${GITHUB_REF#refs/*/}
-        if [[ $BRANCH =~ ^v[0-9]+.[0-9]+$ ]]
-        then
-          BUILD_NUMBER=$(( GITHUB_RUN_NUMBER + 500 )) # compensate for old jenkins CI
-          VERSION="${BRANCH#v}.$BUILD_NUMBER"
-          IS_MASTER_BUILD=1
-        else
-          VERSION="0.0.0"
-          IS_MASTER_BUILD=0
-        fi
-        echo Building on "$BRANCH"
-        echo Building version: "$VERSION"
-        
-        echo "::set-env name=VERSION::${VERSION}"
-        echo "::set-env name=IS_MASTER_BUILD::${IS_MASTER_BUILD}"
-    - name: Restore
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-      env:
-        GIT_COMMIT: ${{ github.sha }}
-    - name: Test
-      run: dotnet msbuild /t:RunTests /p:Configuration=Release
-      working-directory: test
-    - name: Pack
-      if: env.IS_MASTER_BUILD == '1'
-      run: dotnet pack --no-build -c Release -o $PWD/packed
-    - name: Publish
-      if: env.IS_MASTER_BUILD == '1'
-      run: find packed/ -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
-      env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.302
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+        env:
+          GIT_COMMIT: ${{ github.sha }}
+      - name: Test
+        run: dotnet msbuild /t:RunTests /p:Configuration=Release
+        working-directory: test
+      - name: Pack
+        if: ${{ needs.prepare.outputs.publish_artifacts == '1' }}
+        env:
+          ZIP: ${{ needs.prepare.outputs.artifacts_name }}
+        run: |
+          dotnet pack --no-build -c Release -o "$PWD/packed"
+          zip -j "$ZIP" "$PWD"/packed/*.nupkg
+      - name: Publish artifacts
+        if: ${{ needs.prepare.outputs.publish_artifacts == '1' }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ needs.prepare.outputs.artifacts_name }}
+          path: ${{ needs.prepare.outputs.artifacts_name }}
+  publish:
+    runs-on: ubuntu-18.04
+    name: Publish to NuGet
+    needs: [prepare, build]
+    if: ${{ needs.prepare.outputs.publish_nugets == '1' }}
+    steps:
+      - name: Fetch build
+        uses: actions/download-artifact@v1
+        with:
+          name: ${{ needs.prepare.outputs.artifacts_name }}
+      - name: Create release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ format('v{0}', needs.prepare.outputs.version) }}
+          release_name: ${{ format('Release v{0}', needs.prepare.outputs.version) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP: ${{ needs.prepare.outputs.artifacts_name }}
+      - name: Push to NuGet
+        run: |
+          unzip "$ZIP"
+          find packed/ -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -109,7 +109,7 @@ jobs:
           ZIP: ${{ needs.prepare.outputs.artifacts_name }}
       - name: Push to NuGet
         run: |
-          unzip "$ZIP"
-          find packed/ -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
+          unzip "$ZIP" -d packages
+          find packages/ -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
Migrating the updated workflow to the main v4.2 branch because:
-  manual workflow has to be on main branch to be active
- the names of the jobs changed and branch protection rules enforce all selected jobs to be done.

Plus I realized I forgot to set the nuget api key in v5.0 :stuck_out_tongue: 