### PR TITLE
Feature/mass transit 7

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,7 @@
 
     <HangfireVersion>1.7.11</HangfireVersion>
     <IdentityServerVersion>4.0.4</IdentityServerVersion>
-    <MassTransitVersion>6.2.4</MassTransitVersion>
+    <MassTransitVersion>7.0.3</MassTransitVersion>
 
     <!-- Do not bump these dependencies if you don't want to force users to use newer .NET Core SDK -->
     <CodeAnalysisVersion>3.4.0</CodeAnalysisVersion>

--- a/docs/basics/03_mass_transit_integration.md
+++ b/docs/basics/03_mass_transit_integration.md
@@ -1,17 +1,15 @@
 # MassTransit Integration
 
-`LeanCode.DomainModels.MassTransitRelay` allows to pass raised events to [MassTransit](https://masstransit-project.com/) bus instead of handling then in in-proc, during the request.
+`LeanCode.DomainModels.MassTransitRelay` allows to pass raised events to [MassTransit](https://masstransit-project.com/) bus. This is the only way of consuming domain events.
 
 ## Configuration
 
 Relay requires the following elements to be configured in the CQRS pipeline (in the following order):
 
 - `CorrelationElement`
-- `StoreAndPublishEventsElement` (`EventsPublisherElement` if the outbox is not necessary)
-- `EventsInterceptorElement`.
+- `StoreAndPublishEventsElement` (`EventsPublisherElement` if the outbox is not necessary).
 
-Additionally, `MassTransitRelayModule` has to be registered, with the assembly catalogs for events and consumers and a bus factory method.
-The consumers registered that way **have to be** `public`. The bus factory method should specify transport and configure the bus and return `IBusControl` in a regular MassTransit way (typically it would call `Bus.Factory.CreateUsingInMemory/CreateUsingAzureServiceBus` etc.).
+Additionally, `MassTransitRelayModule` has to be registered, with the assembly catalogs for events and consumers and a bus factory method. The consumers registered that way **have to be** `public`. The bus factory method should specify transport and configure the bus in a regular MassTransit way (typically it would call `UsingInMemory/UsingAzureServiceBus` etc., see [Mass Transit docs](https://masstransit-project.com/usage/configuration.html#asp-net-core) for more information).
 
 ### Filters
 

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/BusObserverExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/BusObserverExtensions.cs
@@ -3,23 +3,24 @@ using Autofac;
 using MassTransit;
 using MassTransit.BusConfigurators;
 using MassTransit.Transports;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LeanCode.DomainModels.MassTransitRelay
 {
     public static class BusObserverExtensions
     {
-        public static void ConnectBusObservers(this IBusObserverConnector bus, IComponentContext context)
+        public static void ConnectBusObservers(this IBusObserverConnector bus, IBusRegistrationContext context)
         {
-            var observers = context.Resolve<IEnumerable<IBusObserver>>();
+            var observers = context.GetServices<IBusObserver>();
             foreach (var obs in observers)
             {
                 bus.ConnectBusObserver(obs);
             }
         }
 
-        public static void ConnectReceiveEndpointObservers(this IReceiveEndpointObserverConnector rcv, IComponentContext context)
+        public static void ConnectReceiveEndpointObservers(this IReceiveEndpointObserverConnector rcv, IBusRegistrationContext context)
         {
-            var recvObservers = context.Resolve<IEnumerable<IReceiveEndpointObserver>>();
+            var recvObservers = context.GetServices<IReceiveEndpointObserver>();
             foreach (var obs in recvObservers)
             {
                 rcv.ConnectReceiveEndpointObserver(obs);

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayModule.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayModule.cs
@@ -14,26 +14,24 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LeanCode.DomainModels.MassTransitRelay
 {
-    public delegate void BusFactory(IContainerBuilderBusConfigurator busConfig);
-
     public class MassTransitRelayModule : AppModule
     {
         private readonly TypesCatalog consumersCatalog;
         private readonly TypesCatalog eventsCatalog;
-        private readonly BusFactory busFactory;
+        private readonly Action<IContainerBuilderBusConfigurator> busConfig;
         private readonly bool useInbox;
         private readonly bool useOutbox;
 
         public MassTransitRelayModule(
             TypesCatalog consumersCatalog,
             TypesCatalog eventsCatalog,
-            BusFactory? busFactory = null,
+            Action<IContainerBuilderBusConfigurator>? busConfig = null,
             bool useInbox = true,
             bool useOutbox = true)
         {
             this.consumersCatalog = consumersCatalog;
             this.eventsCatalog = eventsCatalog;
-            this.busFactory = busFactory ?? DefaultBusConfigurator;
+            this.busConfig = busConfig ?? DefaultBusConfigurator;
             this.useInbox = useInbox;
             this.useOutbox = useOutbox;
         }
@@ -81,7 +79,7 @@ namespace LeanCode.DomainModels.MassTransitRelay
             builder.AddMassTransit(cfg =>
             {
                 cfg.AddConsumers(consumersCatalog.Assemblies);
-                busFactory(cfg);
+                busConfig(cfg);
             });
         }
 

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayModule.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayModule.cs
@@ -91,14 +91,14 @@ namespace LeanCode.DomainModels.MassTransitRelay
             {
                 var queueName = Assembly.GetEntryAssembly()!.GetName().Name;
 
-                config.UseLogsCorrelation();
-                config.UseRetry(retryConfig =>
-                    retryConfig.Incremental(5, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
-
-                config.UseConsumedMessagesFiltering();
-                config.StoreAndPublishDomainEvents();
                 config.ReceiveEndpoint(queueName, rcv =>
                 {
+                    rcv.UseLogsCorrelation();
+                    rcv.UseRetry(retryConfig =>
+                        retryConfig.Incremental(5, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
+                    rcv.UseConsumedMessagesFiltering();
+                    rcv.StoreAndPublishDomainEvents();
+
                     rcv.ConfigureConsumers(context);
                     rcv.ConnectReceiveEndpointObservers(context);
                 });


### PR DESCRIPTION
Bus configuration in MT 7 slightly changed. Instead of generic `AddBus` method now `UsingInMemory`/`UsingRabbitMQ` variants are preferred. As a result we have to expose the whole MT configurator method. This approach is more flexible, e.g. now we will have full control of MT registration.