### PR TITLE
Publish to FeedZ

### DIFF
--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -93,14 +93,18 @@ jobs:
     runs-on: ubuntu-18.04
     name: Publish to NuGet
     needs: [prepare, build]
-    if: ${{ needs.prepare.outputs.publish_nuget == '1' }}
     steps:
       - name: Fetch build
         id: download
         uses: actions/download-artifact@v2
         with:
           name: ${{ needs.prepare.outputs.artifacts_name }}
+      - name: Push to Feedz
+        run: |
+          unzip "$ZIP"
+          find -name '*.nupkg' -exec dotnet nuget push -k "$FEEDZ_API_KEY" -s 'https://f.feedz.io/leancode/public/nuget/index.json' -n true '{}' ';'
       - name: Create release
+        if: ${{ needs.prepare.outputs.publish_nuget == '1' }}
         uses: actions/create-release@v1
         with:
           tag_name: ${{ format('v{0}', needs.prepare.outputs.version) }}
@@ -108,9 +112,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to NuGet
+        if: ${{ needs.prepare.outputs.publish_nuget == '1' }}
         run: |
           unzip "$ZIP"
           find -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
           ZIP: ${{ needs.prepare.outputs.artifacts_name }}

--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -104,6 +104,9 @@ jobs:
         run: |
           unzip "$ZIP"
           find -name '*.nupkg' -exec dotnet nuget push -k "$FEEDZ_API_KEY" -s 'https://f.feedz.io/leancode/public/nuget/index.json' -n true '{}' ';'
+        env:
+          FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
+          ZIP: ${{ needs.prepare.outputs.artifacts_name }}
       - name: Create release
         if: ${{ needs.prepare.outputs.publish_nuget == '1' }}
         uses: actions/create-release@v1
@@ -119,5 +122,4 @@ jobs:
           find -name '*.nupkg' -exec dotnet nuget push -k "$NUGET_API_KEY" -s 'https://api.nuget.org/v3/index.json' -n true '{}' ';'
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-          FEEDZ_API_KEY: ${{ secrets.FEEDZ_API_KEY }}
           ZIP: ${{ needs.prepare.outputs.artifacts_name }}

--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -91,8 +91,9 @@ jobs:
           path: ${{ needs.prepare.outputs.artifacts_name }}
   publish:
     runs-on: ubuntu-18.04
-    name: Publish to NuGet
+    name: Publish to feeds
     needs: [prepare, build]
+    if: ${{ needs.prepare.outputs.publish_artifacts == '1' }}
     steps:
       - name: Fetch build
         id: download


### PR DESCRIPTION
We need to stop pushing every commit to NuGet. NuGet releases should be stable and our v5 currently is far from being one.

Closes #47 