### PR TITLE
Update packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -48,7 +48,7 @@
 
     <PackageReference Update="Cronos" Version="0.7.0" />
     <PackageReference Update="Dapper" Version="2.0.35" />
-    <PackageReference Update="FluentValidation" Version="8.6.2" />
+    <PackageReference Update="FluentValidation" Version="9.2.2" />
     <PackageReference Update="Glob" Version="1.1.8" />
     <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Update="Polly" Version="7.2.1" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
-    <EntityFrameworkCoreVersion>5.0.0-rc.1.*</EntityFrameworkCoreVersion>
-    <AspNetCoreVersion>5.0.0-rc.1.*</AspNetCoreVersion>
-    <ExtensionsVersion>5.0.0-rc.1.*</ExtensionsVersion>
+    <EntityFrameworkCoreVersion>5.0.0-rc.2.*</EntityFrameworkCoreVersion>
+    <AspNetCoreVersion>5.0.0-rc.2.*</AspNetCoreVersion>
+    <ExtensionsVersion>5.0.0-rc.2.*</ExtensionsVersion>
 
-    <HangfireVersion>1.7.13</HangfireVersion>
+    <HangfireVersion>1.7.16</HangfireVersion>
     <IdentityServerVersion>4.1.1</IdentityServerVersion>
     <MassTransitVersion>7.0.4</MassTransitVersion>
 
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Autofac" Version="5.2.0" />
-    <PackageReference Update="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Update="Autofac" Version="6.0.0" />
+    <PackageReference Update="Autofac.Extensions.DependencyInjection" Version="7.0.2" />
 
     <PackageReference Update="Azure.Extensions.Configuration.Secrets" Version="1.0.0-preview.1" />
     <PackageReference Update="Azure.Identity" Version="1.2.0-preview.5" />
@@ -102,7 +102,7 @@
 
   <ItemGroup>
     <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200812-03" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0-preview-20200921-01" />
     <PackageReference Update="NSubstitute" Version="4.2.2" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.analyzers" Version="0.10.0" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,8 +40,8 @@
     <PackageReference Update="IdentityModel" Version="4.4.0" />
     <PackageReference Update="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
 
-    <PackageReference Update="FirebaseAdmin" Version="1.14.0" />
-    <PackageReference Update="Google.Cloud.Firestore" Version="1.1.0" />
+    <PackageReference Update="FirebaseAdmin" Version="1.17.1" />
+    <PackageReference Update="Google.Cloud.Firestore" Version="2.2.0" />
 
     <PackageReference Update="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Update="Microsoft.Data.SqlClient" Version="2.0.1" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,7 +9,7 @@
     <MassTransitVersion>7.0.4</MassTransitVersion>
 
     <!-- Do not bump these dependencies if you don't want to force users to use newer .NET Core SDK -->
-    <CodeAnalysisVersion>3.4.0</CodeAnalysisVersion>
+    <CodeAnalysisVersion>3.7.0</CodeAnalysisVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -118,6 +118,6 @@
     <AdditionalFiles Include="$(CodeAnalysisSettingsLocation)stylecop.json" />
 
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="'$(NoStyleCop)' != '1'" />
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.113" />
+    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.205" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,7 +28,7 @@
     <PackageReference Update="Autofac.Extensions.DependencyInjection" Version="7.0.2" />
 
     <PackageReference Update="Azure.Extensions.Configuration.Secrets" Version="1.0.0-preview.1" />
-    <PackageReference Update="Azure.Identity" Version="1.2.0-preview.5" />
+    <PackageReference Update="Azure.Identity" Version="1.2.3" />
 
     <PackageReference Update="Serilog" Version="2.10.0" />
     <PackageReference Update="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/benchmarks/LeanCode.Benchmarks/PipelineObjects.cs
+++ b/benchmarks/LeanCode.Benchmarks/PipelineObjects.cs
@@ -36,7 +36,10 @@ namespace LeanCode.Benchmarks.Pipelines
         private readonly PassthroughElement element = new PassthroughElement();
         private readonly Finalizer finalizer = new Finalizer();
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
 
         public IPipelineElement<TContext, TInput, TOutput> ResolveElement<TContext, TInput, TOutput>(Type type)
             where TContext : IPipelineContext

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.0-rc.1.*",
+    "version": "5.0.0-rc.2.*",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Domain/LeanCode.CQRS.Validation.Fluent/ContextualPropertyRule.cs
+++ b/src/Domain/LeanCode.CQRS.Validation.Fluent/ContextualPropertyRule.cs
@@ -15,12 +15,12 @@ namespace LeanCode.CQRS.Validation.Fluent
     {
         private const string InstanceUnderValidationKey = "InstanceUnderValidation";
 
-        private readonly Func<ValidationContext, object, object?> realValueFunc;
+        private readonly Func<IValidationContext, object, object?> realValueFunc;
 
         public ContextualPropertyRule(
             MemberInfo? member,
             Func<object, object>? propertyFunc,
-            Func<ValidationContext, object, object?> realValueFunc,
+            Func<IValidationContext, object, object?> realValueFunc,
             LambdaExpression? expression,
             Func<CascadeMode>? cascadeModeThunk,
             Type? typeToValidate,
@@ -30,7 +30,7 @@ namespace LeanCode.CQRS.Validation.Fluent
             this.realValueFunc = realValueFunc;
         }
 
-        public override IEnumerable<ValidationFailure> Validate(ValidationContext context)
+        public override IEnumerable<ValidationFailure> Validate(IValidationContext context)
         {
             context.RootContextData[InstanceUnderValidationKey] = GetRealValue(context);
 
@@ -38,7 +38,7 @@ namespace LeanCode.CQRS.Validation.Fluent
         }
 
         public override Task<IEnumerable<ValidationFailure>> ValidateAsync(
-            ValidationContext context,
+            IValidationContext context,
             CancellationToken cancellation)
         {
             context.RootContextData[InstanceUnderValidationKey] = GetRealValue(context);
@@ -47,7 +47,7 @@ namespace LeanCode.CQRS.Validation.Fluent
         }
 
         protected override IEnumerable<ValidationFailure> InvokePropertyValidator(
-            ValidationContext context,
+            IValidationContext context,
             IPropertyValidator validator,
             string propertyName)
         {
@@ -57,7 +57,7 @@ namespace LeanCode.CQRS.Validation.Fluent
         }
 
         protected override Task<IEnumerable<ValidationFailure>> InvokePropertyValidatorAsync(
-            ValidationContext context,
+            IValidationContext context,
             IPropertyValidator validator,
             string propertyName,
             CancellationToken cancellation)
@@ -67,7 +67,7 @@ namespace LeanCode.CQRS.Validation.Fluent
             return validator.ValidateAsync(propContext, cancellation);
         }
 
-        private PropertyValidatorContext CreatePropertyContext(ValidationContext context, string propertyName)
+        private PropertyValidatorContext CreatePropertyContext(IValidationContext context, string propertyName)
         {
             var realValue = context.RootContextData[InstanceUnderValidationKey];
             var propContext = new PropertyValidatorContext(context, this, propertyName, realValue);
@@ -75,7 +75,7 @@ namespace LeanCode.CQRS.Validation.Fluent
             return propContext;
         }
 
-        private object? GetRealValue(ValidationContext context)
+        private object? GetRealValue(IValidationContext context)
         {
             var propValue = PropertyFunc(context.InstanceToValidate);
 
@@ -87,12 +87,12 @@ namespace LeanCode.CQRS.Validation.Fluent
     {
         private const string InstanceUnderValidationKey = "InstanceUnderValidation";
 
-        private readonly Func<ValidationContext, object, Task<object?>> realValueFunc;
+        private readonly Func<IValidationContext, object, Task<object?>> realValueFunc;
 
         public AsyncContextualPropertyRule(
             MemberInfo? member,
             Func<object, object>? propertyFunc,
-            Func<ValidationContext, object, Task<object?>> realValueFunc,
+            Func<IValidationContext, object, Task<object?>> realValueFunc,
             LambdaExpression? expression,
             Func<CascadeMode>? cascadeModeThunk,
             Type? typeToValidate,
@@ -102,13 +102,13 @@ namespace LeanCode.CQRS.Validation.Fluent
             this.realValueFunc = realValueFunc;
         }
 
-        public override IEnumerable<ValidationFailure> Validate(ValidationContext context)
+        public override IEnumerable<ValidationFailure> Validate(IValidationContext context)
         {
             throw new NotSupportedException("Cannot execute async validator in sync context.");
         }
 
         public override async Task<IEnumerable<ValidationFailure>> ValidateAsync(
-            ValidationContext context,
+            IValidationContext context,
             CancellationToken cancellation)
         {
             context.RootContextData[InstanceUnderValidationKey] = await GetRealValueAsync(context);
@@ -117,7 +117,7 @@ namespace LeanCode.CQRS.Validation.Fluent
         }
 
         protected override IEnumerable<ValidationFailure> InvokePropertyValidator(
-            ValidationContext context,
+            IValidationContext context,
             IPropertyValidator validator,
             string propertyName)
         {
@@ -127,7 +127,7 @@ namespace LeanCode.CQRS.Validation.Fluent
         }
 
         protected override async Task<IEnumerable<ValidationFailure>> InvokePropertyValidatorAsync(
-            ValidationContext context,
+            IValidationContext context,
             IPropertyValidator validator,
             string propertyName,
             CancellationToken cancellation)
@@ -137,7 +137,7 @@ namespace LeanCode.CQRS.Validation.Fluent
             return await validator.ValidateAsync(propContext, cancellation);
         }
 
-        private PropertyValidatorContext CreatePropertyContext(ValidationContext context, string propertyName)
+        private PropertyValidatorContext CreatePropertyContext(IValidationContext context, string propertyName)
         {
             var realValue = context.RootContextData[InstanceUnderValidationKey];
             var propContext = new PropertyValidatorContext(context, this, propertyName, realValue);
@@ -145,7 +145,7 @@ namespace LeanCode.CQRS.Validation.Fluent
             return propContext;
         }
 
-        private async Task<object?> GetRealValueAsync(ValidationContext context)
+        private async Task<object?> GetRealValueAsync(IValidationContext context)
         {
             var propValue = PropertyFunc(context.InstanceToValidate);
 

--- a/src/Domain/LeanCode.CQRS.Validation.Fluent/ContextualValidator.cs
+++ b/src/Domain/LeanCode.CQRS.Validation.Fluent/ContextualValidator.cs
@@ -10,11 +10,11 @@ namespace LeanCode.CQRS.Validation.Fluent
     {
         public IRuleBuilderInitial<T, TValue> RuleFor<TProperty, TValue>(
             Expression<Func<T, TProperty>> expression,
-            Func<ValidationContext, TProperty, TValue> realValueAccessor)
+            Func<IValidationContext, TProperty, TValue> realValueAccessor)
         {
             var member = expression.GetMember();
 
-            var compiled = member is null || ValidatorOptions.DisableAccessorCache
+            var compiled = member is null || ValidatorOptions.Global.DisableAccessorCache
                 ? expression.Compile()
                 : AccessorCache<T>.GetCachedAccessor(member, expression);
 
@@ -34,11 +34,11 @@ namespace LeanCode.CQRS.Validation.Fluent
 
         public IRuleBuilderInitial<T, TValue> RuleForAsync<TProperty, TValue>(
             Expression<Func<T, TProperty>> expression,
-            Func<ValidationContext, TProperty, Task<TValue>> realValueAccessor)
+            Func<IValidationContext, TProperty, Task<TValue>> realValueAccessor)
         {
             var member = expression.GetMember();
 
-            var compiled = member is null || ValidatorOptions.DisableAccessorCache
+            var compiled = member is null || ValidatorOptions.Global.DisableAccessorCache
                 ? expression.Compile()
                 : AccessorCache<T>.GetCachedAccessor(member, expression);
 

--- a/src/Domain/LeanCode.CQRS.Validation.Fluent/FluentValidationCommandValidatorAdapter.cs
+++ b/src/Domain/LeanCode.CQRS.Validation.Fluent/FluentValidationCommandValidatorAdapter.cs
@@ -49,7 +49,7 @@ namespace LeanCode.CQRS.Validation.Fluent
             var ctx = new ValidationContext<TCommand>(
                 command,
                 new PropertyChain(),
-                ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory());
+                ValidatorOptions.Global.ValidatorSelectors.DefaultValidatorSelectorFactory());
 
             ctx.RootContextData[ValidationContextExtensions.AppContextKey] = appContext;
             ctx.RootContextData[ValidationContextExtensions.ComponentContextKey] = componentContext;

--- a/src/Domain/LeanCode.CQRS.Validation.Fluent/ValidationContextExtensions.cs
+++ b/src/Domain/LeanCode.CQRS.Validation.Fluent/ValidationContextExtensions.cs
@@ -9,7 +9,7 @@ namespace LeanCode.CQRS.Validation.Fluent
         public const string ComponentContextKey = "ComponentContext";
         public const string AppContextKey = "AppContext";
 
-        public static TAppContext AppContext<TAppContext>(this ValidationContext ctx)
+        public static TAppContext AppContext<TAppContext>(this IValidationContext ctx)
             where TAppContext : class
         {
             if (ctx.RootContextData.TryGetValue(AppContextKey, out var ac))
@@ -22,7 +22,7 @@ namespace LeanCode.CQRS.Validation.Fluent
             }
         }
 
-        public static T GetService<T>(this ValidationContext ctx)
+        public static T GetService<T>(this IValidationContext ctx)
             where T : class
         {
             if (ctx.RootContextData.TryGetValue(ComponentContextKey, out var cc))

--- a/src/Tools/LeanCode.CodeAnalysis/AnalyzerReleases.Shipped.md
+++ b/src/Tools/LeanCode.CodeAnalysis/AnalyzerReleases.Shipped.md
@@ -1,0 +1,8 @@
+## Release 1.0
+
+### New Rules
+Rule ID -| Category | Severity | Notes
+---------|----------|----------|--------------------
+LNCD0001 | Security |   Error  | EnsureCommandsAndQueriesHaveAuthorizers
+LNCD0002 | Security |   Error  | EnsureCommandsAndQueriesHaveAuthorizers
+LNCD0003 |  Usage   |   Info   | SuggestCommandsHaveValidators

--- a/src/Tools/LeanCode.CodeAnalysis/Analyzers/EnsureCommandsAndQueriesHaveAuthorizers.cs
+++ b/src/Tools/LeanCode.CodeAnalysis/Analyzers/EnsureCommandsAndQueriesHaveAuthorizers.cs
@@ -12,7 +12,6 @@ namespace LeanCode.CodeAnalysis.Analyzers
         private const string CommandTypeName = "LeanCode.CQRS.ICommand";
         private const string QueryTypeName = "LeanCode.CQRS.IQuery";
 
-#pragma warning disable RS2008
         private static readonly DiagnosticDescriptor CommandRule = new DiagnosticDescriptor(
             DiagnosticsIds.CommandsShouldHaveAuthorizers,
             "Command should be authorized",
@@ -28,7 +27,6 @@ namespace LeanCode.CodeAnalysis.Analyzers
             Category,
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
-#pragma warning restore RS2008
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(CommandRule, QueryRule);
 

--- a/src/Tools/LeanCode.CodeAnalysis/Analyzers/EnsureCommandsAndQueriesHaveAuthorizers.cs
+++ b/src/Tools/LeanCode.CodeAnalysis/Analyzers/EnsureCommandsAndQueriesHaveAuthorizers.cs
@@ -12,6 +12,7 @@ namespace LeanCode.CodeAnalysis.Analyzers
         private const string CommandTypeName = "LeanCode.CQRS.ICommand";
         private const string QueryTypeName = "LeanCode.CQRS.IQuery";
 
+#pragma warning disable RS2008
         private static readonly DiagnosticDescriptor CommandRule = new DiagnosticDescriptor(
             DiagnosticsIds.CommandsShouldHaveAuthorizers,
             "Command should be authorized",
@@ -27,6 +28,7 @@ namespace LeanCode.CodeAnalysis.Analyzers
             Category,
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
+#pragma warning restore RS2008
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(CommandRule, QueryRule);
 

--- a/src/Tools/LeanCode.CodeAnalysis/Analyzers/NamedTypeSymbolExtensions.cs
+++ b/src/Tools/LeanCode.CodeAnalysis/Analyzers/NamedTypeSymbolExtensions.cs
@@ -43,8 +43,9 @@ namespace LeanCode.CodeAnalysis.Analyzers
         {
             var attributes = type.GetAttributes();
             if (attributes.Any(attr =>
-                attr.AttributeClass.ImplementsInterfaceOrBaseClass(AuthorizeWhenTypeName) ||
-                attr.AttributeClass.ImplementsInterfaceOrBaseClass(AllowUnauthorizedTypeName)))
+                attr.AttributeClass is object &&
+                (attr.AttributeClass.ImplementsInterfaceOrBaseClass(AuthorizeWhenTypeName) ||
+                attr.AttributeClass.ImplementsInterfaceOrBaseClass(AllowUnauthorizedTypeName))))
             {
                 return true;
             }

--- a/src/Tools/LeanCode.CodeAnalysis/Analyzers/SuggestCommandsHaveValidators.cs
+++ b/src/Tools/LeanCode.CodeAnalysis/Analyzers/SuggestCommandsHaveValidators.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -13,7 +14,6 @@ namespace LeanCode.CodeAnalysis.Analyzers
         private const string HandlerTypeName = "LeanCode.CQRS.Execution.ICommandHandler`2";
         private const string ValidatorTypeName = "FluentValidation.IValidator`1";
 
-#pragma warning disable RS2008
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticsIds.CommandsShouldHaveValidators,
             "Commands should be validated",
@@ -21,7 +21,6 @@ namespace LeanCode.CodeAnalysis.Analyzers
             "Cqrs",
             DiagnosticSeverity.Info,
             true);
-#pragma warning restore RS2008
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
@@ -29,12 +28,12 @@ namespace LeanCode.CodeAnalysis.Analyzers
         {
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
-            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+            context.RegisterSyntaxNodeAction(AnalyzeSymbol, SyntaxKind.ClassDeclaration);
         }
 
-        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        private static void AnalyzeSymbol(SyntaxNodeAnalysisContext context)
         {
-            var type = (INamedTypeSymbol)context.Symbol;
+            var type = (INamedTypeSymbol)context.ContainingSymbol!;
 
             if (!IsCommandHandler(type, out var commandType))
             {
@@ -42,16 +41,15 @@ namespace LeanCode.CodeAnalysis.Analyzers
             }
 
             var tree = type.DeclaringSyntaxReferences.First().SyntaxTree;
-            var model = context.Compilation.GetSemanticModel(tree);
 
-            if (!CommandIsValidated(commandType, tree, model))
+            if (!CommandIsValidated(commandType, tree, context.SemanticModel))
             {
                 var diagnostic = Diagnostic.Create(Rule, type.Locations[0], commandType.Name);
                 context.ReportDiagnostic(diagnostic);
             }
         }
 
-        private static bool IsCommandHandler(INamedTypeSymbol type, [NotNullWhen(true)]out INamedTypeSymbol? commandType)
+        private static bool IsCommandHandler(INamedTypeSymbol type, [NotNullWhen(true)] out INamedTypeSymbol? commandType)
         {
             var handler = type.AllInterfaces.FirstOrDefault(i => i.GetFullNamespaceName() == HandlerTypeName);
 

--- a/src/Tools/LeanCode.CodeAnalysis/Analyzers/SuggestCommandsHaveValidators.cs
+++ b/src/Tools/LeanCode.CodeAnalysis/Analyzers/SuggestCommandsHaveValidators.cs
@@ -13,6 +13,7 @@ namespace LeanCode.CodeAnalysis.Analyzers
         private const string HandlerTypeName = "LeanCode.CQRS.Execution.ICommandHandler`2";
         private const string ValidatorTypeName = "FluentValidation.IValidator`1";
 
+#pragma warning disable RS2008
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticsIds.CommandsShouldHaveValidators,
             "Commands should be validated",
@@ -20,6 +21,7 @@ namespace LeanCode.CodeAnalysis.Analyzers
             "Cqrs",
             DiagnosticSeverity.Info,
             true);
+#pragma warning restore RS2008
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/src/Tools/LeanCode.CodeAnalysis/CodeActions/AddAuthorizationAttributeCodeAction.cs
+++ b/src/Tools/LeanCode.CodeAnalysis/CodeActions/AddAuthorizationAttributeCodeAction.cs
@@ -38,7 +38,9 @@ namespace LeanCode.CodeAnalysis.CodeActions
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken);
             var root = await document.GetSyntaxRootAsync(cancellationToken);
 
-            var classDeclaration = root!.FindNode(classSpan).FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            var classDeclaration =
+                root!.FindNode(classSpan).FirstAncestorOrSelf<ClassDeclarationSyntax>()
+                ?? throw new InvalidOperationException("Cannot find parent class.");
 
             var authorizer = SF.Attribute(SF.ParseName(StripAttributeSuffix(authorizationAttribute)));
             var list = SF.AttributeList(SF.SingletonSeparatedList(authorizer)).WithTrailingTrivia(SF.ParseTrailingTrivia("\n"));

--- a/src/Tools/LeanCode.CodeAnalysis/CodeActions/AddCommandValidatorCodeAction.cs
+++ b/src/Tools/LeanCode.CodeAnalysis/CodeActions/AddCommandValidatorCodeAction.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,8 +42,10 @@ namespace LeanCode.CodeAnalysis.CodeActions
                 return document;
             }
 
-            var handlerSyntax = root.FindNode(handlerSpan).FirstAncestorOrSelf<ClassDeclarationSyntax>();
-            var concreteHandler = editor.SemanticModel.GetDeclaredSymbol(handlerSyntax) as INamedTypeSymbol;
+            var handlerSyntax =
+                root.FindNode(handlerSpan).FirstAncestorOrSelf<ClassDeclarationSyntax>() ??
+                throw new InvalidOperationException("Cannot find parent class.");
+            var concreteHandler = editor.SemanticModel.GetDeclaredSymbol(handlerSyntax)!;
             var handlerInteface = concreteHandler.AllInterfaces
                 .FirstOrDefault(i => i.GetFullNamespaceName() == HandlerFullTypeName);
 

--- a/src/Tools/LeanCode.CodeAnalysis/LeanCode.CodeAnalysis.csproj
+++ b/src/Tools/LeanCode.CodeAnalysis/LeanCode.CodeAnalysis.csproj
@@ -30,5 +30,7 @@
     <None Include="LeanCode.CodeAnalysis.props" Pack="true" PackagePath="build" />
     <None Include="$(CodeAnalysisSettingsLocation)/LeanCode.CodeAnalysis.ruleset" Pack="true" PackagePath="build" />
     <None Include="$(CodeAnalysisSettingsLocation)/stylecop.json" Pack="true" PackagePath="build" />
+
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
   </ItemGroup>
 </Project>

--- a/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/ShortcircuitingJsonHandler.cs
+++ b/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/ShortcircuitingJsonHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -55,9 +56,9 @@ namespace LeanCode.CQRS.RemoteHttp.Client.Tests
                 }
             }
 
-            foreach (var prop in req.Properties)
+            foreach (var prop in req.Options)
             {
-                clone.Properties.Add(prop);
+                ((IDictionary<string, object?>)clone.Options).Add(prop);
             }
 
             foreach (var header in req.Headers)

--- a/test/Domain/LeanCode.CQRS.Validation.Fluent.Tests/AsyncContextualPropertyRuleTests.cs
+++ b/test/Domain/LeanCode.CQRS.Validation.Fluent.Tests/AsyncContextualPropertyRuleTests.cs
@@ -13,7 +13,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         {
             const string value = "Value";
             string dataPassed = null;
-            Task<object> Accessor(ValidationContext ctx, string str)
+            Task<object> Accessor(IValidationContext ctx, string str)
             {
                 dataPassed = str;
                 return Task.FromResult<object>(null);
@@ -28,8 +28,8 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         [Fact]
         public async Task Passes_the_context_to_accessor()
         {
-            ValidationContext dataPassed = null;
-            Task<object> Accessor(ValidationContext ctx2, string str)
+            IValidationContext dataPassed = null;
+            Task<object> Accessor(IValidationContext ctx2, string str)
             {
                 dataPassed = ctx2;
                 return Task.FromResult<object>(null);
@@ -58,7 +58,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         public async Task The_accessor_is_called_only_once_for_multiple_validation_rules()
         {
             int calledCount = 0;
-            Task<object> Accessor(ValidationContext ctx, object data)
+            Task<object> Accessor(IValidationContext ctx, object data)
             {
                 return Task.FromResult((object)Interlocked.Increment(ref calledCount));
             }
@@ -81,7 +81,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
 
         private class TestValidator : ContextualValidator<SampleData>
         {
-            public TestValidator(Func<ValidationContext, string, Task<object>> accessor, Func<object, bool> must = null)
+            public TestValidator(Func<IValidationContext, string, Task<object>> accessor, Func<object, bool> must = null)
             {
                 RuleForAsync(d => d.Test, accessor).Must(must ?? (e => true));
             }
@@ -89,7 +89,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
 
         private class MultiValidator : ContextualValidator<SampleData>
         {
-            public MultiValidator(Func<ValidationContext, string, Task<object>> accessor)
+            public MultiValidator(Func<IValidationContext, string, Task<object>> accessor)
             {
                 RuleForAsync(d => d.Test, accessor)
                     .Must(e => true)

--- a/test/Domain/LeanCode.CQRS.Validation.Fluent.Tests/ContextualPropertyRuleTests.cs
+++ b/test/Domain/LeanCode.CQRS.Validation.Fluent.Tests/ContextualPropertyRuleTests.cs
@@ -13,7 +13,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         {
             const string value = "Value";
             string dataPassed = null;
-            object Func(ValidationContext ctx, string str)
+            object Func(IValidationContext ctx, string str)
             {
                 dataPassed = str;
                 return null;
@@ -28,8 +28,8 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         [Fact]
         public void Passes_the_context_to_accessor()
         {
-            ValidationContext dataPassed = null;
-            object Func(ValidationContext ctx2, string str)
+            IValidationContext dataPassed = null;
+            object Func(IValidationContext ctx2, string str)
             {
                 dataPassed = ctx2;
                 return null;
@@ -59,7 +59,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         {
             const string value = "Value";
             string dataPassed = null;
-            object Func(ValidationContext ctx, string str)
+            object Func(IValidationContext ctx, string str)
             {
                 dataPassed = str;
                 return null;
@@ -74,8 +74,8 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         [Fact]
         public async Task Passes_the_context_to_accessor_async()
         {
-            ValidationContext dataPassed = null;
-            object Func(ValidationContext ctx2, string str)
+            IValidationContext dataPassed = null;
+            object Func(IValidationContext ctx2, string str)
             {
                 dataPassed = ctx2;
                 return null;
@@ -104,7 +104,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         public void The_accessor_is_called_only_once_for_multiple_validation_rules_sync_case()
         {
             int calledCount = 0;
-            object Accessor(ValidationContext ctx, object data)
+            object Accessor(IValidationContext ctx, object data)
             {
                 return Interlocked.Increment(ref calledCount);
             }
@@ -119,7 +119,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
         public async Task The_accessor_is_called_only_once_for_multiple_validation_rules_async_case()
         {
             int calledCount = 0;
-            object Accessor(ValidationContext ctx, object data)
+            object Accessor(IValidationContext ctx, object data)
             {
                 return Interlocked.Increment(ref calledCount);
             }
@@ -132,7 +132,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
 
         private class TestValidator : ContextualValidator<SampleData>
         {
-            public TestValidator(Func<ValidationContext, string, object> accessor, Func<object, bool> must = null)
+            public TestValidator(Func<IValidationContext, string, object> accessor, Func<object, bool> must = null)
             {
                 RuleFor(d => d.Test, accessor).Must(must ?? (e => true));
             }
@@ -140,7 +140,7 @@ namespace LeanCode.CQRS.Validation.Fluent.Tests
 
         private class MultiValidator : ContextualValidator<SampleData>
         {
-            public MultiValidator(Func<ValidationContext, string, object> accessor)
+            public MultiValidator(Func<IValidationContext, string, object> accessor)
             {
                 RuleFor(d => d.Test, accessor)
                     .Must(_ => true)

--- a/test/IntegrationTests/App/Program.cs
+++ b/test/IntegrationTests/App/Program.cs
@@ -8,11 +8,6 @@ namespace LeanCode.IntegrationTests.App
 {
     public static class Program
     {
-        public static Task Main(string[] args)
-        {
-            return CreateWebHostBuilder(args).Build().RunAsync();
-        }
-
         [SuppressMessage("?", "IDE0060", Justification = "`args` are required by convention.")]
         public static IWebHostBuilder CreateWebHostBuilder(string[] args)
         {

--- a/test/Testing/LeanCode.IntegrationTestHelpers.Tests/App/Program.cs
+++ b/test/Testing/LeanCode.IntegrationTestHelpers.Tests/App/Program.cs
@@ -8,11 +8,6 @@ namespace LeanCode.IntegrationTestHelpers.Tests.App
 {
     public static class Program
     {
-        public static Task Main(string[] args)
-        {
-            return CreateWebHostBuilder(args).Build().RunAsync();
-        }
-
         [SuppressMessage("?", "IDE0060", Justification = "`args` are required by convention.")]
         public static IWebHostBuilder CreateWebHostBuilder(string[] args)
         {


### PR DESCRIPTION
Updates all packages to the newest versions:
1. Autofac (obsoletes PR #124 & #126),
2. Google's libs (PR #121),
3. FluentValidation (PR #125),
4. Identity (PR #127),
5. CodeAnalysis (PR #128),
6. Other (Hangfire, test runner, StyleCop).

Along the bumps, the new fixes were applied (i.e. new StyleCop rules, new CodeAnalysis rules & new Roslyn rules).