### PR TITLE
MassTransit inactivity monitor

### DIFF
--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/LeanCode.DomainModels.MassTransitRelay.csproj
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/LeanCode.DomainModels.MassTransitRelay.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="../../Core/LeanCode.Components/LeanCode.Components.csproj" />
     <ProjectReference Include="../../Core/LeanCode.Pipelines/LeanCode.Pipelines.csproj" />
+    <ProjectReference Include="../../Infrastructure/LeanCode.AsyncInitializer/LeanCode.AsyncInitializer.csproj" />
     <ProjectReference Include="../../Infrastructure/LeanCode.Correlation/LeanCode.Correlation.csproj" />
     <ProjectReference Include="../../Infrastructure/LeanCode.Dapper/LeanCode.Dapper.csproj" />
     <ProjectReference Include="../../Infrastructure/LeanCode.PeriodicService/LeanCode.PeriodicService.csproj" />

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayHostedService.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayHostedService.cs
@@ -1,23 +1,21 @@
-using System.Threading;
 using System.Threading.Tasks;
+using LeanCode.AsyncInitializer;
 using MassTransit;
-using Microsoft.Extensions.Hosting;
 
 namespace LeanCode.DomainModels.MassTransitRelay
 {
-    public class MassTransitRelayHostedService : IHostedService
+    public class MassTransitRelayHostedService : IAsyncInitializable
     {
         private readonly IBusControl bus;
+
+        public int Order => int.MaxValue;
 
         public MassTransitRelayHostedService(IBusControl bus)
         {
             this.bus = bus;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken) =>
-            bus.StartAsync(cancellationToken);
-
-        public Task StopAsync(CancellationToken cancellationToken) =>
-            bus.StopAsync(cancellationToken);
+        public Task InitializeAsync() => bus.StartAsync();
+        public Task DeinitializeAsync() => bus.StopAsync();
     }
 }

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayModule.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/MassTransitRelayModule.cs
@@ -38,8 +38,6 @@ namespace LeanCode.DomainModels.MassTransitRelay
 
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddHostedService<MassTransitRelayHostedService>();
-
             if (useInbox)
             {
                 services.AddHostedService<PeriodicHostedService<ConsumedMessagesCleaner>>();
@@ -81,6 +79,10 @@ namespace LeanCode.DomainModels.MassTransitRelay
                 cfg.AddConsumers(consumersCatalog.Assemblies);
                 busConfig(cfg);
             });
+
+            builder.RegisterType<MassTransitRelayHostedService>()
+                .AsImplementedInterfaces()
+                .SingleInstance();
         }
 
         public static void DefaultBusConfigurator(IContainerBuilderBusConfigurator busCfg)

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
@@ -8,11 +8,21 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
 {
     public class MassTransitTestRelayModule : AppModule
     {
-        public static readonly TimeSpan NoActivityGranule = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan inactivityTimeout;
+
+        public MassTransitTestRelayModule()
+        {
+            this.inactivityTimeout = TimeSpan.FromSeconds(1);
+        }
+
+        public MassTransitTestRelayModule(TimeSpan inactivityTimeout)
+        {
+            this.inactivityTimeout = inactivityTimeout;
+        }
 
         protected override void Load(ContainerBuilder builder)
         {
-            builder.Register(c => c.Resolve<IBusControl>().CreateBusActivityMonitor(NoActivityGranule))
+            builder.Register(c => c.Resolve<IBusControl>().CreateBusActivityMonitor(inactivityTimeout))
                 .AutoActivate()
                 .AsImplementedInterfaces()
                 .SingleInstance();

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
@@ -1,0 +1,21 @@
+using System;
+using Autofac;
+using LeanCode.Components;
+using MassTransit;
+using MassTransit.Testing;
+
+namespace LeanCode.DomainModels.MassTransitRelay.Testing
+{
+    public class MassTransitTestRelayModule : AppModule
+    {
+        public static readonly TimeSpan NoActivityGranule = TimeSpan.FromSeconds(1);
+
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.Register(c => c.Resolve<IBusControl>().CreateBusActivityMonitor(NoActivityGranule))
+                .AutoActivate()
+                .AsImplementedInterfaces()
+                .SingleInstance();
+        }
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
@@ -120,8 +120,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
 
         private async Task WaitForConsumers()
         {
-            // 5 because of the single retry + wait granule
-            var result = await testApp.ActivityMonitor.AwaitBusInactivity(TimeSpan.FromSeconds(5) + MassTransitTestRelayModule.NoActivityGranule);
+            // 5 because of the retries + inactivity timeout
+            var result = await testApp.ActivityMonitor.AwaitBusInactivity(TimeSpan.FromSeconds(6));
             Assert.True(result, "The bus did not stabilize.");
         }
     }

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using LeanCode.DomainModels.MassTransitRelay.Inbox;
 using LeanCode.DomainModels.MassTransitRelay.Outbox;
+using LeanCode.DomainModels.MassTransitRelay.Testing;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -28,7 +29,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
             await PublishEvents();
             await TestEventsFromCommandHandler();
             await TestEventsFromConsumers();
-            await TestFailingHandlers();
+            TestFailingHandlers();
             await AssertRaisedEventsWerePeristedAndMarkedPublished();
             await AssertConsumedEventsWerePersisted();
         }
@@ -60,10 +61,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
                 e => AssertConsumed(e, typeof(Event2SecondConsumer)));
         }
 
-        private async Task TestFailingHandlers()
+        private void TestFailingHandlers()
         {
-            await Task.Delay(5_500);
-
             var handled = testApp.HandledEvents<Event3>();
             var evt = Assert.Single(handled);
 
@@ -119,6 +118,11 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
             Assert.True(evt.WasPublished);
         }
 
-        private static Task WaitForConsumers() => Task.Delay(500);
+        private async Task WaitForConsumers()
+        {
+            // 5 because of the single retry + wait granule
+            var result = await testApp.ActivityMonitor.AwaitBusInactivity(TimeSpan.FromSeconds(5) + MassTransitTestRelayModule.NoActivityGranule);
+            Assert.True(result, "The bus did not stabilize.");
+        }
     }
 }

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/TestApp.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/TestApp.cs
@@ -28,7 +28,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
                 query => query),
 
             new MassTransitRelayModule(SearchAssemblies, SearchAssemblies),
-            new MassTransitTestRelayModule(),
+            new MassTransitTestRelayModule(TimeSpan.FromSeconds(1)),
             new CorrelationModule(),
         };
 

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/LeanCode.DomainModels.MassTransitRelay.Tests.csproj
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/LeanCode.DomainModels.MassTransitRelay.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="../../../src/Domain/LeanCode.DomainModels.MassTransitRelay/LeanCode.DomainModels.MassTransitRelay.csproj" />
     <ProjectReference Include="../../../src/Domain/LeanCode.CQRS.Default/LeanCode.CQRS.Default.csproj" />
-
-    <ProjectReference Include="../../../src/Testing/LeanCode.IntegrationTestHelpers/LeanCode.IntegrationTestHelpers.csproj" />
-    <ProjectReference Include="../../../src/Domain/LeanCode.TimeProvider/LeanCode.TimeProvider.csproj" />
+    <ProjectReference Include="../../../src/Domain/LeanCode.CQRS.RemoteHttp.Server/LeanCode.CQRS.RemoteHttp.Server.csproj" />
+    <ProjectReference Include="../../../src/Domain/LeanCode.DomainModels.MassTransitRelay/LeanCode.DomainModels.MassTransitRelay.csproj" />
     <ProjectReference Include="../../../src/Domain/LeanCode.IdentityProvider/LeanCode.IdentityProvider.csproj" />
+    <ProjectReference Include="../../../src/Domain/LeanCode.TimeProvider/LeanCode.TimeProvider.csproj" />
+    <ProjectReference Include="../../../src/Testing/LeanCode.IntegrationTestHelpers/LeanCode.IntegrationTestHelpers.csproj" />
 
     <ProjectReference Include="../../LeanCode.Test.Helpers/LeanCode.Test.Helpers.csproj" />
   </ItemGroup>


### PR DESCRIPTION

`InMemoryTestHarness` can also be used, but I think that it is slightly broken - the `inactivity` task timeouts right when the inactivity should be reported, therefore we need to use the monitor to correctly wait for inactivity even in that case.

Test harness has _some_ additional properties (like tracking messages & consumers), but I don't think we should use them in the integration tests. Therefore I think that using much, much simpler solution is a better choice for now.

After all one can rewrite this once again. :)