### PR TITLE
MassTransit inactivity, part 2

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -122,6 +122,6 @@
     <AdditionalFiles Include="$(CodeAnalysisSettingsLocation)stylecop.json" />
 
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="'$(NoStyleCop)' != '1'" />
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.205" />
+    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.261" />
   </ItemGroup>
 </Project>

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GreenPipes.Internals.Extensions;
+
+namespace LeanCode.DomainModels.MassTransitRelay.Testing
+{
+    // Based on https://github.com/StephenCleary/AsyncEx/blob/master/src/Nito.AsyncEx.Coordination/AsyncManualResetEvent.cs
+    public sealed class AsyncManualResetEvent
+    {
+        private readonly object mutex;
+        private TaskCompletionSource<object?> tcs;
+
+        public AsyncManualResetEvent(bool set)
+        {
+            mutex = new object();
+            tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            if (set)
+            {
+                tcs.TrySetResult(null);
+            }
+        }
+
+        public AsyncManualResetEvent()
+            : this(false)
+        { }
+
+        public bool IsSet
+        {
+            get
+            {
+                lock (mutex)
+                {
+                    return tcs.Task.IsCompleted;
+                }
+            }
+        }
+
+        public Task WaitAsync()
+        {
+            lock (mutex)
+            {
+                return tcs.Task;
+            }
+        }
+
+        public Task WaitAsync(CancellationToken cancellationToken)
+        {
+            var waitTask = WaitAsync();
+            if (waitTask.IsCompleted)
+            {
+                return waitTask;
+            }
+            else
+            {
+                return waitTask.OrCanceled(cancellationToken);
+            }
+        }
+
+        public async Task<bool> WaitAsync(TimeSpan timeout)
+        {
+            try
+            {
+                await WaitAsync().OrTimeout(timeout);
+                return true;
+            }
+            catch (TimeoutException)
+            {
+                return false;
+            }
+        }
+
+        public void Set()
+        {
+            lock (mutex)
+            {
+                tcs.TrySetResult(null);
+            }
+        }
+
+        public void Reset()
+        {
+            lock (mutex)
+            {
+                if (tcs.Task.IsCompleted)
+                {
+                    tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+            }
+        }
+    }
+}

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
@@ -9,16 +9,16 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
     public sealed class AsyncManualResetEvent
     {
         private readonly object mutex;
-        private TaskCompletionSource<object?> tcs;
+        private TaskCompletionSource<ValueTuple> tcs;
 
         public AsyncManualResetEvent(bool set)
         {
             mutex = new object();
-            tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            tcs = new TaskCompletionSource<ValueTuple>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             if (set)
             {
-                tcs.TrySetResult(null);
+                tcs.TrySetResult(new ValueTuple());
             }
         }
 
@@ -75,7 +75,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                tcs.TrySetResult(null);
+                tcs.TrySetResult(new ValueTuple());
             }
         }
 
@@ -85,7 +85,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
             {
                 if (tcs.Task.IsCompleted)
                 {
-                    tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    tcs = new TaskCompletionSource<ValueTuple>(TaskCreationOptions.RunContinuationsAsynchronously);
                 }
             }
         }

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
@@ -14,7 +14,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         public AsyncManualResetEvent(bool set)
         {
             mutex = new object();
-            tcs = new TaskCompletionSource<ValueTuple>(TaskCreationOptions.RunContinuationsAsynchronously);
+            tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             if (set)
             {
@@ -85,7 +85,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
             {
                 if (tcs.Task.IsCompleted)
                 {
-                    tcs = new TaskCompletionSource<ValueTuple>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
                 }
             }
         }

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/AsyncManualResetEvent.cs
@@ -18,7 +18,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
 
             if (set)
             {
-                tcs.TrySetResult(new ValueTuple());
+                tcs.TrySetResult(default);
             }
         }
 
@@ -75,7 +75,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                tcs.TrySetResult(new ValueTuple());
+                tcs.TrySetResult(default);
             }
         }
 

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
@@ -2,27 +2,26 @@ using System;
 using Autofac;
 using LeanCode.Components;
 using MassTransit;
-using MassTransit.Testing;
 
 namespace LeanCode.DomainModels.MassTransitRelay.Testing
 {
     public class MassTransitTestRelayModule : AppModule
     {
-        private readonly TimeSpan inactivityTimeout;
+        private readonly TimeSpan inactivityWaitTime;
 
         public MassTransitTestRelayModule()
         {
-            this.inactivityTimeout = TimeSpan.FromSeconds(1);
+            inactivityWaitTime = TimeSpan.FromSeconds(1);
         }
 
-        public MassTransitTestRelayModule(TimeSpan inactivityTimeout)
+        public MassTransitTestRelayModule(TimeSpan inactivityWaitTime)
         {
-            this.inactivityTimeout = inactivityTimeout;
+            this.inactivityWaitTime = inactivityWaitTime;
         }
 
         protected override void Load(ContainerBuilder builder)
         {
-            builder.Register(c => c.Resolve<IBusControl>().CreateBusActivityMonitor(inactivityTimeout))
+            builder.Register(c => ResettableBusActivityMonitor.CreateFor(c.Resolve<IBusControl>(), inactivityWaitTime))
                 .AutoActivate()
                 .AsImplementedInterfaces()
                 .SingleInstance();

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/ResettableBusActivityMonitor.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/ResettableBusActivityMonitor.cs
@@ -17,8 +17,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         private readonly AsyncManualResetEvent inactive = new AsyncManualResetEvent(true);
         private readonly RollingTimer timer;
 
-        private int consumersInFlight;
-        private int receiversInFlight;
+        private volatile int consumersInFlight;
+        private volatile int receiversInFlight;
 
         public ResettableBusActivityMonitor(TimeSpan inactivityWaitTime)
         {
@@ -42,7 +42,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                Interlocked.Decrement(ref consumersInFlight);
+                consumersInFlight--;
                 CheckCondition();
             }
 
@@ -54,7 +54,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                Interlocked.Decrement(ref consumersInFlight);
+                consumersInFlight--;
                 CheckCondition();
             }
 
@@ -66,7 +66,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                Interlocked.Increment(ref consumersInFlight);
+                consumersInFlight++;
                 Reset();
             }
 
@@ -77,7 +77,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                Interlocked.Increment(ref receiversInFlight);
+                receiversInFlight++;
                 Reset();
             }
 
@@ -88,7 +88,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                Interlocked.Decrement(ref receiversInFlight);
+                receiversInFlight--;
                 CheckCondition();
             }
 
@@ -109,7 +109,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                Interlocked.Decrement(ref receiversInFlight);
+                receiversInFlight--;
                 CheckCondition();
             }
 
@@ -126,8 +126,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
 
         private void CheckCondition()
         {
-            if (Volatile.Read(ref consumersInFlight) == 0 &&
-                Volatile.Read(ref receiversInFlight) == 0)
+            if (consumersInFlight == 0 && receiversInFlight == 0)
             {
                 timer.Restart();
             }
@@ -137,8 +136,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         {
             lock (mutex)
             {
-                if (Volatile.Read(ref consumersInFlight) == 0 &&
-                    Volatile.Read(ref receiversInFlight) == 0)
+                if (consumersInFlight == 0 && receiversInFlight == 0)
                 {
                     inactive.Set();
                 }

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/ResettableBusActivityMonitor.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/ResettableBusActivityMonitor.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MassTransit;
+using MassTransit.Testing.Indicators;
+using MassTransit.Util;
+
+namespace LeanCode.DomainModels.MassTransitRelay.Testing
+{
+    public class ResettableBusActivityMonitor :
+        IBusActivityMonitor,
+        IReceiveObserver,
+        IConsumeObserver,
+        IDisposable
+    {
+        private readonly object mutex = new object();
+        private readonly AsyncManualResetEvent inactive = new AsyncManualResetEvent(true);
+        private readonly RollingTimer timer;
+
+        private int consumersInFlight;
+        private int receiversInFlight;
+
+        public ResettableBusActivityMonitor(TimeSpan inactivityWaitTime)
+        {
+            timer = new RollingTimer(OnTimer, inactivityWaitTime);
+        }
+
+        public static ResettableBusActivityMonitor CreateFor(IBusControl bus, TimeSpan inactivityWaitTime)
+        {
+            var monitor = new ResettableBusActivityMonitor(inactivityWaitTime);
+            bus.ConnectConsumeObserver(monitor);
+            bus.ConnectReceiveObserver(monitor);
+            return monitor;
+        }
+
+        public Task AwaitBusInactivity() => inactive.WaitAsync();
+        public Task<bool> AwaitBusInactivity(TimeSpan timeout) => inactive.WaitAsync(timeout);
+        public Task AwaitBusInactivity(CancellationToken cancellationToken) => inactive.WaitAsync(cancellationToken);
+
+        Task IConsumeObserver.ConsumeFault<T>(ConsumeContext<T> context, Exception exception)
+            where T : class
+        {
+            lock (mutex)
+            {
+                Interlocked.Decrement(ref consumersInFlight);
+                CheckCondition();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        Task IConsumeObserver.PostConsume<T>(ConsumeContext<T> context)
+            where T : class
+        {
+            lock (mutex)
+            {
+                Interlocked.Decrement(ref consumersInFlight);
+                CheckCondition();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        Task IConsumeObserver.PreConsume<T>(ConsumeContext<T> context)
+            where T : class
+        {
+            lock (mutex)
+            {
+                Interlocked.Increment(ref consumersInFlight);
+                Reset();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        Task IReceiveObserver.PreReceive(ReceiveContext context)
+        {
+            lock (mutex)
+            {
+                Interlocked.Increment(ref receiversInFlight);
+                Reset();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        Task IReceiveObserver.PostReceive(ReceiveContext context)
+        {
+            lock (mutex)
+            {
+                Interlocked.Decrement(ref receiversInFlight);
+                CheckCondition();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        Task IReceiveObserver.PostConsume<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task IReceiveObserver.ConsumeFault<T>(ConsumeContext<T> context, TimeSpan duration, string consumerType, Exception exception)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task IReceiveObserver.ReceiveFault(ReceiveContext context, Exception exception)
+        {
+            lock (mutex)
+            {
+                Interlocked.Decrement(ref receiversInFlight);
+                CheckCondition();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        void IDisposable.Dispose() => timer.Dispose();
+
+        private void Reset()
+        {
+            inactive.Reset();
+            timer.Stop();
+        }
+
+        private void CheckCondition()
+        {
+            if (Volatile.Read(ref consumersInFlight) == 0 &&
+                Volatile.Read(ref receiversInFlight) == 0)
+            {
+                timer.Restart();
+            }
+        }
+
+        private void OnTimer(object? timer)
+        {
+            lock (mutex)
+            {
+                if (Volatile.Read(ref consumersInFlight) == 0 &&
+                    Volatile.Read(ref receiversInFlight) == 0)
+                {
+                    inactive.Set();
+                }
+            }
+        }
+    }
+}

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/ResettableBusActivityMonitor.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/ResettableBusActivityMonitor.cs
@@ -14,7 +14,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
         IDisposable
     {
         private readonly object mutex = new object();
-        private readonly AsyncManualResetEvent inactive = new AsyncManualResetEvent(true);
+        private readonly AsyncManualResetEvent inactive = new(true);
         private readonly RollingTimer timer;
 
         private volatile int consumersInFlight;

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
@@ -120,8 +120,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
 
         private async Task WaitForConsumers()
         {
-            // 5 because of the retries + inactivity timeout
-            var result = await testApp.ActivityMonitor.AwaitBusInactivity(TimeSpan.FromSeconds(6));
+            // 5 because of the retries + inactivity timeout + some buffer
+            var result = await testApp.ActivityMonitor.AwaitBusInactivity(TimeSpan.FromSeconds(10));
             Assert.True(result, "The bus did not stabilize.");
         }
     }

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Testing/ResettableBusActivityMonitorTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Testing/ResettableBusActivityMonitorTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using GreenPipes.Internals.Extensions;
+using LeanCode.DomainModels.MassTransitRelay.Testing;
+using MassTransit;
+using Xunit;
+
+namespace LeanCode.DomainModels.MassTransitRelay.Tests.Testing
+{
+    public class ResettableBusActivityMonitorTests
+    {
+        private readonly ResettableBusActivityMonitor monitor = new ResettableBusActivityMonitor(TimeSpan.FromSeconds(0.2));
+
+        [Fact]
+        public void Is_inactive_by_default()
+        {
+            Assert.True(monitor.AwaitBusInactivity().IsCompleted);
+        }
+
+        [Fact]
+        public void Makes_itself_inactive_after_first_new_consumer()
+        {
+            _ = ((IConsumeObserver)monitor).PreConsume<object>(null!);
+
+            Assert.False(monitor.AwaitBusInactivity().IsCompleted);
+        }
+
+        [Fact]
+        public void Makes_itself_inactive_after_first_new_receiver()
+        {
+            _ = ((IReceiveObserver)monitor).PreReceive(null!);
+
+            Assert.False(monitor.AwaitBusInactivity().IsCompleted);
+        }
+
+        [Fact]
+        public void Does_not_set_itself_right_after_cosumers_stabilize()
+        {
+            _ = ((IConsumeObserver)monitor).PreConsume<object>(null!);
+            _ = ((IConsumeObserver)monitor).PostConsume<object>(null!);
+
+            Assert.False(monitor.AwaitBusInactivity().IsCompleted);
+        }
+
+        [Fact]
+        public async Task Sets_itself_after_the_delay()
+        {
+            await ((IConsumeObserver)monitor).PreConsume<object>(null!);
+            await ((IConsumeObserver)monitor).PostConsume<object>(null!);
+
+            await monitor.AwaitBusInactivity().OrTimeout(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task Sets_the_inactivity_after_equal_pre_and_post_consumes()
+        {
+            const int Repeat = 10;
+            for (var i = 0; i < Repeat; i++)
+            {
+                await ((IConsumeObserver)monitor).PreConsume<object>(null!);
+            }
+
+            for (var i = 0; i < Repeat; i++)
+            {
+                await ((IConsumeObserver)monitor).PostConsume<object>(null!);
+            }
+
+            await monitor.AwaitBusInactivity().OrTimeout(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task If_the_calls_dont_compensate_the_inactivity_is_not_set()
+        {
+            const int Repeat = 10;
+            for (var i = 0; i < Repeat; i++)
+            {
+                await ((IConsumeObserver)monitor).PreConsume<object>(null!);
+            }
+
+            for (var i = 0; i < Repeat - 1; i++)
+            {
+                await ((IConsumeObserver)monitor).PostConsume<object>(null!);
+            }
+
+            await Assert.ThrowsAsync<TimeoutException>(() => monitor.AwaitBusInactivity().OrTimeout(TimeSpan.FromSeconds(1)));
+        }
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Testing/ResettableBusActivityMonitorTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Testing/ResettableBusActivityMonitorTests.cs
@@ -103,5 +103,26 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Testing
             var res = await monitor.AwaitBusInactivity(TimeSpan.FromSeconds(1));
             Assert.True(res);
         }
+
+        [Fact]
+        public async Task Toggling_inactivity_works_as_expected()
+        {
+            await ((IConsumeObserver)monitor).PreConsume<object>(null!);
+            await ((IConsumeObserver)monitor).PostConsume<object>(null!);
+
+            var res1 = await monitor.AwaitBusInactivity(TimeSpan.FromSeconds(1));
+            Assert.True(res1);
+
+            await ((IConsumeObserver)monitor).PreConsume<object>(null!);
+
+            Assert.False(monitor.AwaitBusInactivity().IsCompleted);
+            var res2 = await monitor.AwaitBusInactivity(TimeSpan.FromSeconds(0.5));
+            Assert.False(res2);
+
+            await ((IConsumeObserver)monitor).PostConsume<object>(null!);
+
+            var res3 = await monitor.AwaitBusInactivity(TimeSpan.FromSeconds(1));
+            Assert.True(res3);
+        }
     }
 }

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Testing/ResettableBusActivityMonitorTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Testing/ResettableBusActivityMonitorTests.cs
@@ -84,5 +84,24 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Testing
 
             await Assert.ThrowsAsync<TimeoutException>(() => monitor.AwaitBusInactivity().OrTimeout(TimeSpan.FromSeconds(1)));
         }
+
+        [Fact]
+        public async Task Await_with_timeout_returns_false_if_the_event_is_not_triggered()
+        {
+            await ((IConsumeObserver)monitor).PreConsume<object>(null!);
+
+            var res = await monitor.AwaitBusInactivity(TimeSpan.FromMilliseconds(1));
+            Assert.False(res);
+        }
+
+        [Fact]
+        public async Task Await_with_timeout_returns_true_if_the_event_is_triggered()
+        {
+            await ((IConsumeObserver)monitor).PreConsume<object>(null!);
+            await ((IConsumeObserver)monitor).PostConsume<object>(null!);
+
+            var res = await monitor.AwaitBusInactivity(TimeSpan.FromSeconds(1));
+            Assert.True(res);
+        }
     }
 }


### PR DESCRIPTION
Well... It's not _that_ simple.

`BusActivityMonitor` uses under the hood the `SemaphoreSlim` class (with single reentrance) which, IMO, is quite unfortunate. This has this nasty side effect that the code will lock forever (provided that there are no stray messages left):

```
await monitor.AwaitBusInactivity();
await monitor.AwaitBusInactivity();
```

Also, if you don't send any message to the bus and call the `AwaitBusInactivity`, the returned task will never end. There are also problems with thread-safety since the semaphore is released only once and therefore it will only unlock a single thread, but that is more of a "nice to know" than real problem for us.

In this PR, I introduce somewhat simplified version of the `IBusActivityMonitor` that is "resettable" and works more like a toggle than a semaphore (i.e. it behaves as `ManualResetEvent` and not `AutoResetEvent`). It counts the consumers and message receives since counting sends and publishes won't add much (in-memory bus is _fast_ in this regard). After there are no more outstanding consumers/receives, it triggers a timer that gives some time for the bus to stabilize.

Note that this won't exactly allow for consumer retries if they are not _instant_ - if the delay between restarts is longer than inactivity wait time, the monitor will be toggled in-between. I think this is a nice side effect, as we should not rely on restarts in integration tests, really. :)