### PR TITLE
MassTransit inactivity monitor improvements

### DIFF
--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Testing/MassTransitTestRelayModule.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Reflection;
 using Autofac;
+using GreenPipes;
 using LeanCode.Components;
+using LeanCode.DomainModels.MassTransitRelay.Middleware;
 using MassTransit;
+using MassTransit.AutofacIntegration;
 
 namespace LeanCode.DomainModels.MassTransitRelay.Testing
 {
@@ -25,6 +29,27 @@ namespace LeanCode.DomainModels.MassTransitRelay.Testing
                 .AutoActivate()
                 .AsImplementedInterfaces()
                 .SingleInstance();
+        }
+
+        public static void TestBusConfigurator(IContainerBuilderBusConfigurator busCfg)
+        {
+            busCfg.UsingInMemory((context, config) =>
+            {
+                var queueName = Assembly.GetEntryAssembly()!.GetName().Name;
+
+                config.ReceiveEndpoint(queueName, rcv =>
+                {
+                    rcv.UseLogsCorrelation();
+                    rcv.UseRetry(retryConfig => retryConfig.Immediate(5));
+                    rcv.UseConsumedMessagesFiltering();
+                    rcv.StoreAndPublishDomainEvents();
+
+                    rcv.ConfigureConsumers(context);
+                    rcv.ConnectReceiveEndpointObservers(context);
+                });
+
+                config.ConnectBusObservers(context);
+            });
         }
     }
 }

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/TestApp.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/TestApp.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Data.Common;
+using System.Reflection;
 using System.Threading.Tasks;
 using Autofac;
+using GreenPipes;
 using LeanCode.Components;
 using LeanCode.Correlation;
 using LeanCode.CQRS.Default;
@@ -11,6 +13,7 @@ using LeanCode.DomainModels.MassTransitRelay.Testing;
 using LeanCode.DomainModels.Model;
 using LeanCode.IdentityProvider;
 using MassTransit;
+using MassTransit.AutofacIntegration;
 using MassTransit.Testing.Indicators;
 using Microsoft.Data.Sqlite;
 using Xunit;
@@ -27,8 +30,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
                 cmd => cmd.Correlate().StoreAndPublishEvents(),
                 query => query),
 
-            new MassTransitRelayModule(SearchAssemblies, SearchAssemblies),
-            new MassTransitTestRelayModule(TimeSpan.FromSeconds(1)),
+            new MassTransitRelayModule(SearchAssemblies, SearchAssemblies, MassTransitTestRelayModule.TestBusConfigurator),
+            new MassTransitTestRelayModule(),
             new CorrelationModule(),
         };
 


### PR DESCRIPTION
It's not that simple, part 3.

Having the `ResettableBusActivityMonitor` be set by default has it's nasty consequences - some tests won't wait for the consumers because MassTransit will not be able to run the consumer because of task scheduling. Connecting send/publish observers gives it a little bit of time - it will reset the event (& timer) on first `publish` that is run synchronously with the request.