### PR TITLE
Update outdated packages & remove the hack for code actions

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <EntityFrameworkCoreVersion>5.0.0</EntityFrameworkCoreVersion>
-    <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
+    <EntityFrameworkCoreVersion>5.0.1</EntityFrameworkCoreVersion>
+    <AspNetCoreVersion>5.0.1</AspNetCoreVersion>
     <ExtensionsVersion>5.0.0</ExtensionsVersion>
 
     <GoogleApisVersion>1.49.0</GoogleApisVersion>
@@ -10,7 +10,7 @@
     <MassTransitVersion>7.0.7</MassTransitVersion>
 
     <!-- Do not bump these dependencies if you don't want to force users to use newer .NET Core SDK -->
-    <CodeAnalysisVersion>3.7.0</CodeAnalysisVersion>
+    <CodeAnalysisVersion>3.8.0</CodeAnalysisVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -74,7 +74,6 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Configuration" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Hosting" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Http" Version="$(ExtensionsVersion)" />
@@ -84,7 +83,9 @@
     <PackageReference Update="Microsoft.Extensions.Logging.Debug" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
-    <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="$(ExtensionsVersion)" />
+    <!-- Warning: as of 2020.12.11, the rest of `Extension` packages is at version 5.0.0 and these two are at 5.0.1 :) -->
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="5.0.1" />
 
     <PackageReference Update="Google.Apis" Version="$(GoogleApisVersion)" />
     <PackageReference Update="Google.Apis.Auth" Version="$(GoogleApisVersion)" />
@@ -123,6 +124,6 @@
     <AdditionalFiles Include="$(CodeAnalysisSettingsLocation)stylecop.json" />
 
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="'$(NoStyleCop)' != '1'" />
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.261" />
+    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.312" />
   </ItemGroup>
 </Project>

--- a/src/Tools/LeanCode.CodeAnalysis/LeanCode.CodeAnalysis.csproj
+++ b/src/Tools/LeanCode.CodeAnalysis/LeanCode.CodeAnalysis.csproj
@@ -10,16 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-      Omnisharp works on Mono, and it is compatible with .NETStandard2.1 and earlier. When using
-      `netcoreapp` (3.0 in particular) we are implicitly referencing `System.Collections.Immutable.dll`
-      in version 1.2.5.0. Mono has only 1.2.3.0 so it fails to match the version correctly.
-      Fortunately, System.Collections.Immutable package, version 1.5.0 has DLL with the correct version.
-      So we're just forcing MSBuild to use that particular version and everything is fine (although
-      we don't have .NET Core 3.0 features here).
-    -->
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0"/>
-
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="None" />
   </ItemGroup>


### PR DESCRIPTION
We now don't need to override the `System.Collections.Immutable` version - it works as expected without the hack.

Closes #142 