### PR TITLE
Use multiple Sqlite connections in MassTransitRelay tests

### DIFF
--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/ConsumedMessagesFilterTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/ConsumedMessagesFilterTests.cs
@@ -37,7 +37,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests
             {
                 var serviceResolver = Substitute.For<IPipeContextServiceResolver>();
                 serviceResolver.GetService<IConsumedMessagesContext>(null)
-                    .ReturnsForAnyArgs(_ => new TestDbContext(dbConnection));
+                    .ReturnsForAnyArgs(_ => TestDbContext.Create(dbConnection));
 
                 // we have to serialize access to database
                 cfg.UseConcurrencyLimit(1);
@@ -83,7 +83,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests
         [Fact]
         public async Task Does_not_consume_already_consumed_message()
         {
-            using var dbContext = new TestDbContext(dbConnection);
+            using var dbContext = TestDbContext.Create(dbConnection);
             dbContext.Add(new ConsumedMessage(MessageId, TimeProvider.Now, typeof(ReportingConsumer).FullName, typeof(TestMsg).FullName));
             await dbContext.SaveChangesAsync();
 
@@ -121,7 +121,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests
 
         private async Task<List<ConsumedMessage>> FetchConsumedMessages()
         {
-            using var dbContext = new TestDbContext(dbConnection);
+            using var dbContext = TestDbContext.Create(dbConnection);
             return await dbContext.ConsumedMessages
                 .OrderBy(msg => msg.ConsumerType)
                 .ToListAsync();
@@ -141,7 +141,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests
             // await harness.Start();
 
             await dbConnection.OpenAsync();
-            using var dbContext = new TestDbContext(dbConnection);
+            using var dbContext = TestDbContext.Create(dbConnection);
             await dbContext.Database.EnsureCreatedAsync();
         }
 

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/MassTransitIntegrationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Autofac;
 using LeanCode.DomainModels.MassTransitRelay.Inbox;
 using LeanCode.DomainModels.MassTransitRelay.Outbox;
 using LeanCode.DomainModels.MassTransitRelay.Testing;
@@ -71,7 +72,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
 
         private async Task AssertRaisedEventsWerePeristedAndMarkedPublished()
         {
-            using var dbContext = new TestDbContext(testApp.DbConnection);
+            await using var scope = testApp.Container.BeginLifetimeScope();
+            using var dbContext = scope.Resolve<TestDbContext>();
             var raisedEvents = await dbContext.RaisedEvents
                 .OrderBy(e => e.EventType)
                 .ToListAsync();
@@ -85,7 +87,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
 
         private async Task AssertConsumedEventsWerePersisted()
         {
-            using var dbContext = new TestDbContext(testApp.DbConnection);
+            await using var scope = testApp.Container.BeginLifetimeScope();
+            using var dbContext = scope.Resolve<TestDbContext>();
 
             var consumedMsgs = await dbContext.ConsumedMessages
                 .OrderBy(e => e.ConsumerType)

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/TestApp.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Integration/TestApp.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using System.Reflection;
 using System.Threading.Tasks;
 using Autofac;
+using Autofac.Extensions.DependencyInjection;
 using GreenPipes;
 using LeanCode.Components;
 using LeanCode.Correlation;
@@ -16,13 +17,17 @@ using MassTransit;
 using MassTransit.AutofacIntegration;
 using MassTransit.Testing.Indicators;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
 using Xunit;
 
 namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
 {
     public class TestApp : IAsyncLifetime, IDisposable
     {
-        private static readonly TypesCatalog SearchAssemblies = new TypesCatalog(typeof(TestApp));
+        private static readonly TypesCatalog SearchAssemblies = TypesCatalog.Of<TestApp>();
         private readonly AppModule[] modules = new AppModule[]
         {
             new CQRSModule().WithCustomPipelines<Context>(
@@ -35,27 +40,47 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
             new CorrelationModule(),
         };
 
-        private readonly IContainer container;
         private readonly IBusControl bus;
+        private readonly SqliteConnection dbConnection;
 
         public Guid CorrelationId { get; }
-        public DbConnection DbConnection { get; }
+        public IContainer Container { get; }
         public ICommandExecutor<Context> Commands { get; }
         public IBusActivityMonitor ActivityMonitor { get; }
 
         public HandledEvent[] HandledEvents<TEvent>()
             where TEvent : class, IDomainEvent
         {
-            return container.Resolve<HandledEventsReporter<TEvent>>().HandledEvents;
+            return Container.Resolve<HandledEventsReporter<TEvent>>().HandledEvents;
         }
 
         public TestApp()
         {
-            Serilog.Log.Logger = new Serilog.LoggerConfiguration().CreateLogger();
+            Log.Logger = new LoggerConfiguration().CreateLogger();
 
-            DbConnection = new SqliteConnection("Filename=:memory:");
+            // We have to use the same in-mem database but differnet connections so that we don't have
+            // overlapping transactions but still be able to use the same data.
+            var connStr = new SqliteConnectionStringBuilder
+            {
+                DataSource = Guid.NewGuid().ToString("N"),
+                Mode = SqliteOpenMode.Memory,
+                Cache = SqliteCacheMode.Shared,
+            };
+            // The database is destroyed when the last connection to it closes, hence we need
+            // to have one artificial connection to it for the duration of the test, otherwise
+            // it will get dropped prematurely and the tests would fail.
+            dbConnection = new SqliteConnection(connStr.ConnectionString);
+
+            var services = new ServiceCollection();
+            services.AddLogging(cfg => cfg.AddSerilog());
+            services.AddDbContext<TestDbContext>(cfg => cfg.UseSqlite(connStr.ConnectionString));
 
             var builder = new ContainerBuilder();
+            builder.Populate(services);
+
+            builder.Register(c => c.Resolve<TestDbContext>())
+                .AsImplementedInterfaces()
+                .InstancePerLifetimeScope();
 
             builder.RegisterGeneric(typeof(HandledEventsReporter<>))
                 .AsSelf()
@@ -66,37 +91,35 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests.Integration
                 builder.RegisterModule(m);
             }
 
-            builder.Register(ctx => new TestDbContext(DbConnection))
-                .AsImplementedInterfaces()
-                .InstancePerLifetimeScope();
-
-            container = builder.Build();
-            bus = container.Resolve<IBusControl>();
+            Container = builder.Build();
+            bus = Container.Resolve<IBusControl>();
 
             CorrelationId = Identity.NewId();
-            Commands = container.Resolve<ICommandExecutor<Context>>();
-            ActivityMonitor = container.Resolve<IBusActivityMonitor>();
+            Commands = Container.Resolve<ICommandExecutor<Context>>();
+            ActivityMonitor = Container.Resolve<IBusActivityMonitor>();
         }
 
         public void Dispose()
         {
-            DbConnection.Dispose();
-            container.Dispose();
+            Container.Dispose();
         }
 
         public async Task InitializeAsync()
         {
-            await bus.StartAsync();
-            await DbConnection.OpenAsync();
+            await dbConnection.OpenAsync();
 
-            using var dbContext = new TestDbContext(DbConnection);
+            await using var scope = Container.BeginLifetimeScope();
+            using var dbContext = scope.Resolve<TestDbContext>();
             await dbContext.Database.EnsureCreatedAsync();
+
+            await bus.StartAsync();
         }
 
         public async Task DisposeAsync()
         {
             await bus.StopAsync();
-            await DbConnection.CloseAsync();
+            await dbConnection.CloseAsync();
+            await dbConnection.DisposeAsync();
         }
     }
 }

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/StoreAndPublishEventsTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/StoreAndPublishEventsTests.cs
@@ -25,7 +25,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests
 
         public StoreAndPublishEventsTests()
         {
-            dbContext = new TestDbContext();
+            dbContext = TestDbContext.Create();
             dbContext.Database.GetDbConnection().Open();
             dbContext.Database.EnsureCreated();
 

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/TestDbContext.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/TestDbContext.cs
@@ -12,17 +12,23 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests
         public DbSet<ConsumedMessage> ConsumedMessages => Set<ConsumedMessage>();
         public DbSet<RaisedEvent> RaisedEvents => Set<RaisedEvent>();
 
-        public TestDbContext()
-            : base(new DbContextOptionsBuilder<TestDbContext>()
-                .UseSqlite("Filename=:memory:")
-                .Options)
+        public TestDbContext(DbContextOptions<TestDbContext> opts)
+            : base(opts)
         { }
 
-        public TestDbContext(DbConnection connection)
-            : base(new DbContextOptionsBuilder<TestDbContext>()
+        public static TestDbContext Create()
+        {
+            return new TestDbContext(new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlite("Filename=:memory:")
+                .Options);
+        }
+
+        public static TestDbContext Create(DbConnection connection)
+        {
+            return new TestDbContext(new DbContextOptionsBuilder<TestDbContext>()
                 .UseSqlite(connection)
-                .Options)
-        { }
+                .Options);
+        }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
This fixes the flakyness in MassTransit relay tests.

Previously, it used a single connection that was accessed from multiple threads (the tests and MT), making it race for the transaction (during `SaveChangesAsync`). Now we use different connections to the same in-mem database, making the tests thread-safe.

Closes #139