### PR TITLE
Retrieve tokens for multiple users and send single message to multiple users

### DIFF
--- a/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenStore.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenStore.cs
@@ -58,7 +58,7 @@ namespace LeanCode.Firebase.FCM.EntityFramework
             {
                 await dbContext.ExecuteAsync(
                 $@"
-                    BEGIN TRAN;
+                    BEGIN TRANSACTION;
 
                     -- Remove token from (possibly another) user
                     DELETE FROM {GetTokensTableName()} WHERE [Token] = @token;
@@ -67,7 +67,7 @@ namespace LeanCode.Firebase.FCM.EntityFramework
                     INSERT INTO {GetTokensTableName()} ([Id], [UserId], [Token], [DateCreated])
                     VALUES (@newId, @userId, @token, @now);
 
-                    COMMIT TRAN;
+                    COMMIT TRANSACTION;
                 ", new { newId = Identity.NewId(), userId, token, now = TimeProvider.Now },
                 cancellationToken: cancellationToken);
                 logger.Information("Added push notification token for user {UserId} from the store", userId);

--- a/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenStore.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenStore.cs
@@ -14,8 +14,7 @@ namespace LeanCode.Firebase.FCM.EntityFramework
     public sealed class PushNotificationTokenStore<TDbContext> : IPushNotificationTokenStore
         where TDbContext : DbContext
     {
-        private const int MaxBatchSize = 100;
-
+        private const int MaxTokenBatchSize = IPushNotificationTokenStore.MaxTokenBatchSize;
         private readonly Serilog.ILogger logger = Serilog.Log.ForContext<PushNotificationTokenStore<TDbContext>>();
 
         private readonly TDbContext dbContext;
@@ -34,11 +33,11 @@ namespace LeanCode.Firebase.FCM.EntityFramework
             return res.AsList();
         }
 
-        public async Task<Dictionary<Guid, List<string>>> GetTokensAsync(List<Guid> userIds, CancellationToken cancellationToken = default)
+        public async Task<Dictionary<Guid, List<string>>> GetTokensAsync(IReadOnlySet<Guid> userIds, CancellationToken cancellationToken = default)
         {
-            if (userIds.Count > MaxBatchSize)
+            if (userIds.Count > MaxTokenBatchSize)
             {
-                throw new ArgumentException($"You can only pass at most {MaxBatchSize} users in one call.", nameof(userIds));
+                throw new ArgumentException($"You can only pass at most {MaxTokenBatchSize} users in one call.", nameof(userIds));
             }
 
             var res = await dbContext.QueryAsync<UserToken>(

--- a/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenStore.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenStore.cs
@@ -46,9 +46,9 @@ namespace LeanCode.Firebase.FCM.EntityFramework
                 cancellationToken: cancellationToken);
             return res
                 .GroupBy(g => g.UserId)
-                    .ToDictionary(
-                        t => t.Key,
-                        t => t.Select(e => e.Token).ToList());
+                .ToDictionary(
+                    t => t.Key,
+                    t => t.Select(e => e.Token).ToList());
         }
 
         public async Task AddUserTokenAsync(Guid userId, string token, CancellationToken cancellationToken = default)

--- a/src/Infrastructure/LeanCode.Firebase.FCM/FCMClient.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/FCMClient.cs
@@ -69,7 +69,7 @@ namespace LeanCode.Firebase.FCM
 
             if (message.Tokens.Count == 0)
             {
-                logger.Information("Cannot send push to user {UserId} - no tokens", userIds);
+                logger.Information("Cannot send push to users {UserIds} - no tokens", userIds);
             }
             else
             {

--- a/src/Infrastructure/LeanCode.Firebase.FCM/FCMClient.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/FCMClient.cs
@@ -33,7 +33,7 @@ namespace LeanCode.Firebase.FCM
             Localize(CultureInfo.GetCultureInfo(lang));
         public Task SendToUserAsync(Guid userId, MulticastMessage message, CancellationToken cancellationToken = default) =>
             SendToUserAsync(userId, message, false, cancellationToken);
-        public Task SendToUsersAsync(List<Guid> userIds, MulticastMessage message, CancellationToken cancellationToken = default) =>
+        public Task SendToUsersAsync(IReadOnlySet<Guid> userIds, MulticastMessage message, CancellationToken cancellationToken = default) =>
             SendToUsersAsync(userIds, message, false, cancellationToken);
         public Task SendAsync(Message message, CancellationToken cancellationToken = default) =>
             SendAsync(message, false, cancellationToken);
@@ -62,7 +62,7 @@ namespace LeanCode.Firebase.FCM
             }
         }
 
-        public async Task SendToUsersAsync(List<Guid> userIds, MulticastMessage message, bool dryRun, CancellationToken cancellationToken = default)
+        public async Task SendToUsersAsync(IReadOnlySet<Guid> userIds, MulticastMessage message, bool dryRun, CancellationToken cancellationToken = default)
         {
             var tokens = await tokenStore.GetTokensAsync(userIds, cancellationToken);
             message.Tokens = tokens.SelectMany(t => t.Value).ToList();

--- a/src/Infrastructure/LeanCode.Firebase.FCM/IPushNotificationTokenStore.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/IPushNotificationTokenStore.cs
@@ -7,8 +7,10 @@ namespace LeanCode.Firebase.FCM
 {
     public interface IPushNotificationTokenStore
     {
+        public const int MaxTokenBatchSize = 100;
+
         Task<List<string>> GetTokensAsync(Guid userId, CancellationToken cancellationToken = default);
-        Task<Dictionary<Guid, List<string>>> GetTokensAsync(List<Guid> userIds, CancellationToken cancellationToken = default);
+        Task<Dictionary<Guid, List<string>>> GetTokensAsync(IReadOnlySet<Guid> userIds, CancellationToken cancellationToken = default);
 
         Task AddUserTokenAsync(Guid userId, string newToken, CancellationToken cancellationToken = default);
         Task RemoveUserTokenAsync(Guid userId, string newToken, CancellationToken cancellationToken = default);

--- a/src/Infrastructure/LeanCode.Firebase.FCM/IPushNotificationTokenStore.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/IPushNotificationTokenStore.cs
@@ -8,6 +8,8 @@ namespace LeanCode.Firebase.FCM
     public interface IPushNotificationTokenStore
     {
         Task<List<string>> GetTokensAsync(Guid userId, CancellationToken cancellationToken = default);
+        Task<Dictionary<Guid, List<string>>> GetTokensAsync(List<Guid> userIds, CancellationToken cancellationToken = default);
+
         Task AddUserTokenAsync(Guid userId, string newToken, CancellationToken cancellationToken = default);
         Task RemoveUserTokenAsync(Guid userId, string newToken, CancellationToken cancellationToken = default);
 

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/EntityFramework/PushNotificationTokenStoreTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/EntityFramework/PushNotificationTokenStoreTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LeanCode.Firebase.FCM.EntityFramework;
+using Xunit;
+
+namespace LeanCode.Firebase.FCM.Tests.EntityFramework
+{
+    public class PushNotificationTokenStoreTests : IAsyncLifetime
+    {
+        private TestDbContext context = default!;
+        private PushNotificationTokenStore<TestDbContext> store = default!;
+
+        [Fact]
+        public async Task Gets_freshly_saved_token()
+        {
+            const string Token = "token";
+            var uid = Guid.NewGuid();
+
+            await store.AddUserTokenAsync(uid, Token);
+            var result = await store.GetTokensAsync(uid);
+
+            Assert.Equal(new() { Token }, result);
+        }
+
+        [Fact]
+        public async Task Gets_multiple_freshly_saved_token()
+        {
+            const string Token1 = "token1";
+            const string Token2 = "token2";
+            var uid = Guid.NewGuid();
+
+            await store.AddUserTokenAsync(uid, Token1);
+            await store.AddUserTokenAsync(uid, Token2);
+            var result = await store.GetTokensAsync(uid);
+
+            Assert.Equal(new() { Token1, Token2 }, result);
+        }
+
+        [Fact]
+        public async Task Gets_tokens_for_multiple_users()
+        {
+            const string Token1 = "token1";
+            const string Token2 = "token2";
+            var uid1 = Guid.NewGuid();
+            var uid2 = Guid.NewGuid();
+
+            await store.AddUserTokenAsync(uid1, Token1);
+            await store.AddUserTokenAsync(uid2, Token2);
+
+            var result = await store.GetTokensAsync(new List<Guid> { uid1, uid2 });
+
+            Assert.Equal(
+                new()
+                {
+                    [uid1] = new() { Token1 },
+                    [uid2] = new() { Token2 },
+                },
+                result);
+        }
+
+        [Fact]
+        public async Task Removes_single_token()
+        {
+            const string Token1 = "token1";
+            const string Token2 = "token2";
+            var uid = Guid.NewGuid();
+
+            await store.AddUserTokenAsync(uid, Token1);
+            await store.AddUserTokenAsync(uid, Token2);
+            await store.RemoveTokenAsync(Token1);
+            var result = await store.GetTokensAsync(uid);
+
+            Assert.Equal(new() { Token2 }, result);
+        }
+
+        [Fact]
+        public async Task Removes_user_tokens()
+        {
+            const string Token1 = "token1";
+            const string Token2 = "token2";
+            var uid1 = Guid.NewGuid();
+            var uid2 = Guid.NewGuid();
+
+            await store.AddUserTokenAsync(uid1, Token1);
+            await store.AddUserTokenAsync(uid2, Token2);
+
+            await store.RemoveUserTokenAsync(uid1, Token2); // Noop
+            await store.RemoveUserTokenAsync(uid1, Token1);
+
+            var result1 = await store.GetTokensAsync(uid1);
+            var result2 = await store.GetTokensAsync(uid2);
+
+            Assert.Empty(result1);
+            Assert.Equal(new() { Token2 }, result2);
+        }
+
+        [Fact]
+        public async Task Removes_multiple_tokens()
+        {
+            const string Token1 = "token1";
+            const string Token2 = "token2";
+            var uid1 = Guid.NewGuid();
+            var uid2 = Guid.NewGuid();
+
+            await store.AddUserTokenAsync(uid1, Token1);
+            await store.AddUserTokenAsync(uid2, Token2);
+
+            await store.RemoveTokensAsync(new[] { Token1, Token2 });
+
+            var result1 = await store.GetTokensAsync(uid1);
+            var result2 = await store.GetTokensAsync(uid2);
+
+            Assert.Empty(result1);
+            Assert.Empty(result2);
+        }
+
+        public async Task InitializeAsync()
+        {
+            context = await TestDbContext.CreateInMemory();
+            store = new PushNotificationTokenStore<TestDbContext>(context);
+        }
+
+        public async Task DisposeAsync()
+        {
+            await context.DisposeAsync();
+        }
+    }
+}

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/EntityFramework/PushNotificationTokenStoreTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/EntityFramework/PushNotificationTokenStoreTests.cs
@@ -48,7 +48,7 @@ namespace LeanCode.Firebase.FCM.Tests.EntityFramework
             await store.AddUserTokenAsync(uid1, Token1);
             await store.AddUserTokenAsync(uid2, Token2);
 
-            var result = await store.GetTokensAsync(new List<Guid> { uid1, uid2 });
+            var result = await store.GetTokensAsync(new HashSet<Guid> { uid1, uid2 });
 
             Assert.Equal(
                 new()

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/EntityFramework/TestDbContext.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/EntityFramework/TestDbContext.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Dapper;
+using LeanCode.Firebase.FCM.EntityFramework;
+using Microsoft.EntityFrameworkCore;
+
+namespace LeanCode.Firebase.FCM.Tests.EntityFramework
+{
+    public class TestDbContext : DbContext
+    {
+        private readonly DbConnection connection;
+
+        public DbSet<PushNotificationTokenEntity> Tokens { get; set; }
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+            connection = Database.GetDbConnection();
+        }
+
+        public static async Task<TestDbContext> CreateInMemory()
+        {
+            SqlMapper.AddTypeHandler(new GuidTypeHandler());
+
+            var context = new TestDbContext(new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlite("Filename=:memory:")
+                .Options);
+            await context.connection.OpenAsync();
+            await context.Database.EnsureCreatedAsync();
+            return context;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            PushNotificationTokenEntity.Configure(modelBuilder);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await connection.DisposeAsync();
+            await base.DisposeAsync();
+        }
+
+        // Required to make tests work in SQLite that assumes `Guid == string`
+        private class GuidTypeHandler : SqlMapper.TypeHandler<Guid>
+        {
+            public override void SetValue(IDbDataParameter parameter, Guid guid) => parameter.Value = guid.ToString();
+            public override Guid Parse(object value) => Guid.Parse((string)value);
+        }
+    }
+}

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/FCMClientTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/FCMClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FirebaseAdmin.Messaging;
 using LeanCode.Localization.StringLocalizers;
@@ -58,7 +59,7 @@ namespace LeanCode.Firebase.FCM.Tests
                 },
             };
 
-            await client.SendToUsersAsync(new() { UserId }, message);
+            await client.SendToUsersAsync(new HashSet<Guid> { UserId }, message);
         }
 
         [FCMFact]

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/FCMClientTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/FCMClientTests.cs
@@ -47,6 +47,21 @@ namespace LeanCode.Firebase.FCM.Tests
         }
 
         [FCMFact]
+        public async Task Sends_single_message_to_multiple_users()
+        {
+            var message = new MulticastMessage
+            {
+                Notification = new Notification
+                {
+                    Title = "Test title",
+                    Body = "Test body",
+                },
+            };
+
+            await client.SendToUsersAsync(new() { UserId }, message);
+        }
+
+        [FCMFact]
         public async Task Does_nothing_when_user_does_not_have_tokens()
         {
             var message = new MulticastMessage

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/LeanCode.Firebase.FCM.Tests.csproj
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/LeanCode.Firebase.FCM.Tests.csproj
@@ -4,4 +4,8 @@
     <ProjectReference Include="../../../src/Infrastructure/LeanCode.Firebase.FCM/LeanCode.Firebase.FCM.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
 </Project>

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/StubStore.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/StubStore.cs
@@ -42,7 +42,7 @@ namespace LeanCode.Firebase.FCM.Tests
             }
         }
 
-        public Task<Dictionary<Guid, List<string>>> GetTokensAsync(List<Guid> userIds, CancellationToken cancellationToken = default)
+        public Task<Dictionary<Guid, List<string>>> GetTokensAsync(IReadOnlySet<Guid> userIds, CancellationToken cancellationToken = default)
         {
             if (userIds.Contains(userId))
             {

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/StubStore.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/StubStore.cs
@@ -42,6 +42,18 @@ namespace LeanCode.Firebase.FCM.Tests
             }
         }
 
+        public Task<Dictionary<Guid, List<string>>> GetTokensAsync(List<Guid> userIds, CancellationToken cancellationToken = default)
+        {
+            if (userIds.Contains(userId))
+            {
+                return Task.FromResult(new Dictionary<Guid, List<string>> { [userId] = new() { token } });
+            }
+            else
+            {
+                return Task.FromResult(new Dictionary<Guid, List<string>>());
+            }
+        }
+
         public Task RemoveTokensAsync(IEnumerable<string> tokens, CancellationToken cancellationToken = default)
         {
             if (tokens.All(t => t == token))


### PR DESCRIPTION
The `GetTokensAsync(List<Guid>)` limits the number of users to max. 100 so that we don't generate terribly inefficient SQL statement with long `IN` clause.

Closes #189
Closes #92