### PR TITLE
Generate non-`int` constants in Dart

### DIFF
--- a/src/Tools/LeanCode.ContractsGenerator/CodeGenerator.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/CodeGenerator.cs
@@ -214,7 +214,7 @@ namespace LeanCode.ContractsGenerator
             switch (value)
             {
                 case bool v:
-                    return v.ToString().ToLower();
+                    return v.ToString().ToLowerInvariant();
 
                 case string v:
                     return '"' + v + '"';

--- a/src/Tools/LeanCode.ContractsGenerator/Extensions/StringExtensions.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Extensions/StringExtensions.cs
@@ -2,17 +2,12 @@ namespace LeanCode.ContractsGenerator.Extensions
 {
     internal static class StringExtensions
     {
-        public static string Uncapitalize(this string str)
+        public static string ToCamelCase(this string str)
         {
-            if (str == str.ToUpperInvariant())
-            {
-                return str;
-            }
-
             return char.ToLowerInvariant(str[0]) + str[1..];
         }
 
-        public static string Capitalize(this string str)
+        public static string ToPascalCase(this string str)
         {
             return char.ToUpperInvariant(str[0]) + str[1..];
         }

--- a/src/Tools/LeanCode.ContractsGenerator/Extensions/StringExtensions.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Extensions/StringExtensions.cs
@@ -6,10 +6,5 @@ namespace LeanCode.ContractsGenerator.Extensions
         {
             return char.ToLowerInvariant(str[0]) + str[1..];
         }
-
-        public static string ToPascalCase(this string str)
-        {
-            return char.ToUpperInvariant(str[0]) + str[1..];
-        }
     }
 }

--- a/src/Tools/LeanCode.ContractsGenerator/Languages/Dart/DartVisitor.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Languages/Dart/DartVisitor.cs
@@ -51,29 +51,35 @@ namespace LeanCode.ContractsGenerator.Languages.Dart
         private void GenerateHelpers()
         {
             definitionsBuilder
-                .AppendLine("List<T> _listFromJson<T>(")
-                .AppendLine("Iterable<dynamic> decodedJson, T itemFromJson(Map<String, dynamic> map)) {")
-                .AppendLine("return decodedJson?.map((dynamic e) => itemFromJson(e as Map<String,dynamic>))?.toList()?.cast<T>(); }");
+                .AppendLine("List<T> _listFromJson<T>(Iterable<dynamic> decodedJson, T itemFromJson(Map<String, dynamic> map)) {")
+                .AppendLine("    return decodedJson")
+                .AppendLine("        ?.map((dynamic e) => itemFromJson(e as Map<String,dynamic>))")
+                .AppendLine("        ?.toList()")
+                .AppendLine("        ?.cast<T>();")
+                .AppendLine("}");
 
             definitionsBuilder
                 .AppendLine("DateTime _dateTimeFromJson(String value) {")
-                .AppendLine("return DateTime.parse('${value.substring(0, 19)} Z'); }");
+                .AppendLine("    return DateTime.parse('${value.substring(0, 19)} Z');")
+                .AppendLine("}");
 
             definitionsBuilder
                 .AppendLine("DateTime _nullableDateTimeFromJson(String value) {")
-                .AppendLine("return value == null ? null : _dateTimeFromJson(value); }");
+                .AppendLine("    return value == null ? null : _dateTimeFromJson(value);")
+                .AppendLine("}");
 
             definitionsBuilder
                 .AppendLine("double _doubleFromJson(dynamic value) {")
-                .AppendLine("if (value is double) { return value; }")
-                .AppendLine("else if (value is String) { return double.parse(value); }")
-                .AppendLine("else if (value is int) { return value.toDouble(); }")
-                .AppendLine("throw Exception('Invalid argument type ${value.runtimeType}');")
+                .AppendLine("    if (value is double) { return value; }")
+                .AppendLine("    else if (value is String) { return double.parse(value); }")
+                .AppendLine("    else if (value is int) { return value.toDouble(); }")
+                .AppendLine("    else { throw Exception('Invalid argument type ${value.runtimeType}'); }")
                 .AppendLine("}");
 
             definitionsBuilder
                 .AppendLine("double _nullableDoubleFromJson(dynamic value) {")
-                .AppendLine("return value == null ? null : _doubleFromJson(value); }");
+                .AppendLine("    return value == null ? null : _doubleFromJson(value);")
+                .AppendLine("}");
         }
 
         private void GenerateTypeNames(ClientStatement statement)
@@ -502,11 +508,11 @@ namespace LeanCode.ContractsGenerator.Languages.Dart
 
                 foreach (var constant in constants)
                 {
-                    var name = char.ToLower(constant.Name[0]) + constant.Name[1..];
+                    var name = constant.Name.ToCamelCase();
 
                     definitionsBuilder
                         .AppendSpaces(level + 1)
-                        .AppendLine($"static const int {name} = {constant.Value};");
+                        .AppendLine($"static const {name} = {constant.Value};");
                 }
             }
         }
@@ -580,7 +586,7 @@ namespace LeanCode.ContractsGenerator.Languages.Dart
 
         private static string TranslateIdentifier(string identifier)
         {
-            var translated = identifier.Uncapitalize();
+            var translated = identifier.ToCamelCase();
 
             if (translated == "new" || translated == "default")
             {

--- a/src/Tools/LeanCode.ContractsGenerator/Languages/TypeScript/TypeScriptVisitor.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Languages/TypeScript/TypeScriptVisitor.cs
@@ -140,7 +140,7 @@ namespace LeanCode.ContractsGenerator.Languages.TypeScript
 
                 stringBuilder.Append('>');
             }
-            else if (configuration.TypeTranslations.TryGetValue(statement.Name.ToLower(), out var name))
+            else if (configuration.TypeTranslations.TryGetValue(statement.Name.ToLowerInvariant(), out var name))
             {
                 stringBuilder.Append(name);
             }
@@ -216,7 +216,7 @@ namespace LeanCode.ContractsGenerator.Languages.TypeScript
         {
             VisitInterfaceStatement(statement, level, parentName);
 
-            var name = char.ToLower(statement.Name[0]) + statement.Name[1..];
+            var name = statement.Name.ToCamelCase();
 
             clientBuilder
                 .AppendSpaces(2)
@@ -250,7 +250,7 @@ namespace LeanCode.ContractsGenerator.Languages.TypeScript
         {
             VisitInterfaceStatement(statement, level, parentName);
 
-            var name = char.ToLower(statement.Name[0]) + statement.Name[1..];
+            var name = statement.Name.ToCamelCase();
 
             clientBuilder.AppendSpaces(2)
                 .Append(name)

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTestHelpers.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTestHelpers.cs
@@ -32,7 +32,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
             ");
         }
 
-        public static readonly GeneratorConfiguration DefaultDartConfiguration = new GeneratorConfiguration()
+        public static readonly GeneratorConfiguration DefaultDartConfiguration = new()
         {
             Name = "Test",
             Dart = new DartConfiguration { },

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.ClassGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.ClassGeneration.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.Dart.ContractsGeneratorTestHelper
 
 namespace LeanCode.ContractsGenerator.Tests.Dart
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_ClassGeneration
     {
         [Fact]
         public void Private_class_is_not_resolved()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.CommandQueryGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.CommandQueryGeneration.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.Dart.ContractsGeneratorTestHelper
 
 namespace LeanCode.ContractsGenerator.Tests.Dart
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_CommandQueryGeneration
     {
         [Fact]
         public void Remote_query_contains_mapping_from_json_for_DTO()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.ConstantsGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.ConstantsGeneration.cs
@@ -1,23 +1,22 @@
-using System.Text.RegularExpressions;
 using Xunit;
 using static LeanCode.ContractsGenerator.Tests.Dart.ContractsGeneratorTestHelpers;
 
 namespace LeanCode.ContractsGenerator.Tests.Dart
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_ConstantsGeneration
     {
         [Fact]
-        public void Commands_error_code_is_resolved_correctly()
+        public void Commands_error_code_is_generated()
         {
             var generator = CreateDartGeneratorFromNamespace("public class TestClass : IRemoteCommand { public static class ErrorCodes { public const int Invalid = 1; } }");
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
-            Assert.Contains("invalid = 1", contracts);
+            Assert.Contains("static const int invalid = 1", contracts);
         }
 
         [Fact]
-        public void Const_in_nested_static_class_is_resolved_correctly()
+        public void Const_in_nested_static_class_is_generated()
         {
             var generator = CreateDartGeneratorFromNamespace("public static class Constants { public static class Constants2 { public const int Value = 1; } }");
 
@@ -25,18 +24,29 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
 
             Assert.Contains("Constants {", contracts);
             Assert.Contains("Constants2 {", contracts);
-            Assert.Contains("value = 1", contracts);
+            Assert.Contains("static const int value = 1", contracts);
         }
 
         [Fact]
-        public void Multiple_command_error_codes_are_resolved_correctly()
+        public void Multiple_command_error_codes_are_generated()
         {
             var generator = CreateDartGeneratorFromNamespace("public class TestClass : IRemoteCommand { public static class ErrorCodes { public const int Invalid = 1; public const int Empty = 2; } }");
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
-            Assert.Contains("invalid = 1", contracts);
-            Assert.Contains("empty = 2", contracts);
+            Assert.Contains("static const int invalid = 1", contracts);
+            Assert.Contains("static const int empty = 2", contracts);
+        }
+
+        [Fact]
+        public void Constants_in_static_classes_are_generated()
+        {
+            var generator = CreateDartGeneratorFromNamespace("public static class StaticClass { public const int SomeConstant = 1; }");
+
+            var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
+
+            Assert.Contains("StaticClass {", contracts);
+            Assert.Contains("static const int someConstant = 1", contracts);
         }
     }
 }

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.ConstantsGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.ConstantsGeneration.cs
@@ -12,7 +12,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
-            Assert.Contains("static const int invalid = 1", contracts);
+            Assert.Contains("static const invalid = 1", contracts);
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
 
             Assert.Contains("Constants {", contracts);
             Assert.Contains("Constants2 {", contracts);
-            Assert.Contains("static const int value = 1", contracts);
+            Assert.Contains("static const value = 1", contracts);
         }
 
         [Fact]
@@ -34,8 +34,8 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
-            Assert.Contains("static const int invalid = 1", contracts);
-            Assert.Contains("static const int empty = 2", contracts);
+            Assert.Contains("static const invalid = 1", contracts);
+            Assert.Contains("static const empty = 2", contracts);
         }
 
         [Fact]
@@ -46,7 +46,51 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
             Assert.Contains("StaticClass {", contracts);
-            Assert.Contains("static const int someConstant = 1", contracts);
+            Assert.Contains("static const someConstant = 1", contracts);
+        }
+
+        [Fact]
+        public void String_constants_are_generated()
+        {
+            var generator = CreateDartGeneratorFromNamespace("public static class StaticClass { public const string SomeConstant = \"TEST\"; }");
+
+            var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
+
+            Assert.Contains("StaticClass {", contracts);
+            Assert.Contains("static const someConstant = \"TEST\"", contracts);
+        }
+
+        [Fact]
+        public void Double_constants_are_generated()
+        {
+            var generator = CreateDartGeneratorFromNamespace("public static class StaticClass { public const double SomeConstant = 1.23; }");
+
+            var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
+
+            Assert.Contains("StaticClass {", contracts);
+            Assert.Contains("static const someConstant = 1.23", contracts);
+        }
+
+        [Fact]
+        public void Float_constants_are_generated()
+        {
+            var generator = CreateDartGeneratorFromNamespace("public static class StaticClass { public const float SomeConstant = 1.23; }");
+
+            var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
+
+            Assert.Contains("StaticClass {", contracts);
+            Assert.Contains("static const someConstant = 1.23", contracts);
+        }
+
+        [Fact]
+        public void Char_constants_are_generated()
+        {
+            var generator = CreateDartGeneratorFromNamespace("public static class StaticClass { public const char SomeConstant = 'a'; }");
+
+            var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
+
+            Assert.Contains("StaticClass {", contracts);
+            Assert.Contains("static const someConstant = \"a\"", contracts);
         }
     }
 }

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.EnumGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.EnumGeneration.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.Dart.ContractsGeneratorTestHelper
 
 namespace LeanCode.ContractsGenerator.Tests.Dart
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_EnumGeneration
     {
         [Fact]
         public void Enums_have_correct_values()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.MultilinePreambles.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.MultilinePreambles.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace LeanCode.ContractsGenerator.Tests.Dart
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_MultilinePreambles
     {
         [Fact]
         public void Empty_configuration_contains_default_preamble()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.TypesGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.TypesGeneration.cs
@@ -4,7 +4,7 @@ using static LeanCode.ContractsGenerator.Tests.Dart.ContractsGeneratorTestHelper
 
 namespace LeanCode.ContractsGenerator.Tests.Dart
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_TypesGeneration
     {
         [Fact]
         public void Imports_are_generated()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/LeanCode.ContractsGenerator.Tests.csproj
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/LeanCode.ContractsGenerator.Tests.csproj
@@ -4,8 +4,4 @@
     <ProjectReference Include="../../../src/Tools/LeanCode.ContractsGenerator/LeanCode.ContractsGenerator.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" />
-  </ItemGroup>
-
 </Project>

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTestHelpers.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTestHelpers.cs
@@ -31,7 +31,7 @@ namespace LeanCode.ContractsGenerator.Tests.TypeScript
             ");
         }
 
-        public static readonly GeneratorConfiguration DefaultTypeScriptConfiguration = new GeneratorConfiguration()
+        public static readonly GeneratorConfiguration DefaultTypeScriptConfiguration = new()
         {
             Name = "Test",
             TypeScript = new TypeScriptConfiguration

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.ClassGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.ClassGeneration.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTest
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_ClassGeneration
     {
         [Fact]
         public void Private_class_is_not_resolved()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.CommandQueryGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.CommandQueryGeneration.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTest
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_CommandQueryGeneration
     {
         [Fact]
         public void Namespace_name_with_one_element_is_resolved_correctly()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.ConstantsGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.ConstantsGeneration.cs
@@ -1,10 +1,9 @@
-using System.Text.RegularExpressions;
 using Xunit;
 using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTestHelpers;
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_ConstantsGeneration
     {
         [Fact]
         public void Commands_error_code_is_resolved_correctly()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.EnumGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.EnumGeneration.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTest
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_EnumGeneration
     {
         [Fact]
         public void Simple_enum_is_generated_correctly()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.ErrorCodes.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.ErrorCodes.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTest
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_ErrorCodes
     {
         [Fact]
         public void ErrorCodes_are_resolved_correctly_with_default_config()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.MultilinePreambles.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.MultilinePreambles.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_MultilinePreambles
     {
         [Fact]
         public void Empty_configuration_contains_default_preambles()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.NestedTypes.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.NestedTypes.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTest
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_NestedTypes
     {
         [Fact]
         public void Generates_globals_if_type_has_consts()

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.TypesExclusion.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.TypesExclusion.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTest
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_TypesExclusion
     {
         [Theory]
         [InlineData("class")]

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.TypesGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTests.TypesGeneration.cs
@@ -3,7 +3,7 @@ using static LeanCode.ContractsGenerator.Tests.TypeScript.ContractsGeneratorTest
 
 namespace LeanCode.ContractsGenerator.Tests.TypeScript
 {
-    public partial class ContractsGeneratorTests
+    public class ContractsGeneratorTests_TypesGeneration
     {
         [Fact]
         public void Int_is_resolved_to_number()


### PR DESCRIPTION
Fixes #182 