### PR TITLE
Add support for OAuth token–based authentication to SMSAPI client

### DIFF
--- a/src/Infrastructure/LeanCode.SmsSender/LeanCode.SmsSender.csproj
+++ b/src/Infrastructure/LeanCode.SmsSender/LeanCode.SmsSender.csproj
@@ -5,11 +5,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
-    <PackageReference Include="Serilog" />
-
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Serilog" />
   </ItemGroup>
 
 </Project>

--- a/src/Infrastructure/LeanCode.SmsSender/SmsApiClient.cs
+++ b/src/Infrastructure/LeanCode.SmsSender/SmsApiClient.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Runtime.Serialization;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,6 +35,21 @@ namespace LeanCode.SmsSender
 
         private readonly SmsApiConfiguration config;
         private readonly HttpClient client;
+
+        public static void ConfigureHttpClient(SmsApiConfiguration config, HttpClient client)
+        {
+            client.BaseAddress = new Uri(ApiBase);
+
+            if (config.Token is { Length: > 0 } token)
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+            else
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{config.Login}:{config.Password}")));
+            }
+        }
 
         public SmsApiClient(SmsApiConfiguration config, HttpClient client)
         {

--- a/src/Infrastructure/LeanCode.SmsSender/SmsApiClient.cs
+++ b/src/Infrastructure/LeanCode.SmsSender/SmsApiClient.cs
@@ -30,12 +30,13 @@ namespace LeanCode.SmsSender
             999 /* Internal system error */);
 
         private readonly Serilog.ILogger logger = Serilog.Log.ForContext<SmsApiClient>();
-        private readonly HttpClient client;
-        private readonly SmsApiConfiguration smsApiConfiguration;
 
-        public SmsApiClient(SmsApiConfiguration smsApiConfiguration, HttpClient client)
+        private readonly SmsApiConfiguration config;
+        private readonly HttpClient client;
+
+        public SmsApiClient(SmsApiConfiguration config, HttpClient client)
         {
-            this.smsApiConfiguration = smsApiConfiguration;
+            this.config = config;
             this.client = client;
         }
 
@@ -43,40 +44,37 @@ namespace LeanCode.SmsSender
         {
             logger.Verbose("Sending SMS using SMS Api");
 
-            var parameters = new Dictionary<string, string>()
+            var parameters = new Dictionary<string, string?>
             {
-                ["username"] = smsApiConfiguration.Login,
-                ["password"] = smsApiConfiguration.Password,
-                ["from"] = smsApiConfiguration.From,
                 ["format"] = "json",
-                ["encoding"] = "UTF-8",
-                ["message"] = message,
+                ["encoding"] = "UTF-8", // documentation claims it's the default anyway, but let's keep it for safety
+                ["from"] = config.From,
                 ["to"] = phoneNumber,
+                ["message"] = message,
             };
 
-            if (smsApiConfiguration.TestMode)
+            if (config.TestMode)
             {
                 parameters["test"] = "1";
             }
 
-            if (smsApiConfiguration.FastMode)
+            if (config.FastMode)
             {
                 parameters["fast"] = "1";
             }
 
-            using (var body = new FormUrlEncodedContent(parameters!))
-            using (var response = await client.PostAsync("sms.do", body, cancellationToken))
+            using var requestContent = new FormUrlEncodedContent(parameters!);
+            using var response = await client.PostAsync("sms.do", requestContent, cancellationToken);
+
+            await using var responseContent = await response.Content.ReadAsStreamAsync(cancellationToken);
+            try
             {
-                await using var content = await response.Content.ReadAsStreamAsync(cancellationToken);
-                try
-                {
-                    using var doc = JsonDocument.Parse(content);
-                    HandleResponse(doc.RootElement);
-                }
-                catch (Exception e) when (e is JsonException || e is KeyNotFoundException || e is FormatException)
-                {
-                    throw new SerializationException("Failed to parse error message.", e);
-                }
+                using var doc = JsonDocument.Parse(responseContent);
+                HandleResponse(doc.RootElement);
+            }
+            catch (Exception e) when (e is JsonException || e is KeyNotFoundException || e is FormatException)
+            {
+                throw new SerializationException("Failed to parse error message.", e);
             }
 
             logger.Information("SMS sent successfully");

--- a/src/Infrastructure/LeanCode.SmsSender/SmsApiConfiguration.cs
+++ b/src/Infrastructure/LeanCode.SmsSender/SmsApiConfiguration.cs
@@ -1,11 +1,38 @@
+using System;
+
 namespace LeanCode.SmsSender
 {
-    public class SmsApiConfiguration
+    /// <remarks>
+    /// In an effort to preserve some backward compatibility,
+    /// a single class is used for both supported authentication schemes.
+    /// Checking which credentials to use is done manually in the client.
+    /// </remarks>
+    public class SmsApiConfiguration // TODO: change to some immutable record
     {
+        public string? Token { get; set; }
         public string Login { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
         public string From { get; set; } = string.Empty;
         public bool FastMode { get; set; }
         public bool TestMode { get; set; }
+
+        [Obsolete("Use another constructor (preferably the one with token).")]
+        public SmsApiConfiguration() { }
+
+        public SmsApiConfiguration(string login, string password, string from)
+        {
+            Login = login;
+            Password = password;
+            From = from;
+        }
+
+        public SmsApiConfiguration(string token, string from)
+        {
+            Token = token;
+            From = from;
+
+            Login = null!;
+            Password = null!;
+        }
     }
 }

--- a/src/Infrastructure/LeanCode.SmsSender/SmsSenderModule.cs
+++ b/src/Infrastructure/LeanCode.SmsSender/SmsSenderModule.cs
@@ -11,19 +11,9 @@ namespace LeanCode.SmsSender
         public override void ConfigureServices(IServiceCollection services) =>
             services.AddHttpClient<ISmsSender, SmsApiClient>((sp, c) =>
             {
-                c.BaseAddress = new Uri(SmsApiClient.ApiBase);
-
                 var config = sp.GetRequiredService<SmsApiConfiguration>();
 
-                if (config.Token is { Length: > 0 } token)
-                {
-                    c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                }
-                else
-                {
-                    c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
-                        "Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{config.Login}:{config.Password}")));
-                }
+                SmsApiClient.ConfigureHttpClient(config, c);
             });
     }
 }

--- a/src/Infrastructure/LeanCode.SmsSender/SmsSenderModule.cs
+++ b/src/Infrastructure/LeanCode.SmsSender/SmsSenderModule.cs
@@ -1,5 +1,6 @@
 using System;
-using Autofac;
+using System.Net.Http.Headers;
+using System.Text;
 using LeanCode.Components;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,21 @@ namespace LeanCode.SmsSender
     public class SmsSenderModule : AppModule
     {
         public override void ConfigureServices(IServiceCollection services) =>
-            services.AddHttpClient<ISmsSender, SmsApiClient>(c => c.BaseAddress = new Uri(SmsApiClient.ApiBase));
+            services.AddHttpClient<ISmsSender, SmsApiClient>((sp, c) =>
+            {
+                c.BaseAddress = new Uri(SmsApiClient.ApiBase);
+
+                var config = sp.GetRequiredService<SmsApiConfiguration>();
+
+                if (config.Token is { Length: > 0 } token)
+                {
+                    c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                }
+                else
+                {
+                    c.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                        "Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{config.Login}:{config.Password}")));
+                }
+            });
     }
 }

--- a/test/Infrastructure/LeanCode.SmsSender.Tests/SmsSenderClientTests.cs
+++ b/test/Infrastructure/LeanCode.SmsSender.Tests/SmsSenderClientTests.cs
@@ -9,25 +9,18 @@ namespace LeanCode.SmsSender.Tests
 {
     public class SmsSenderClientTests
     {
-        private static readonly string Login = string.Empty;
-        private static readonly string Password = string.Empty;
+        private static readonly string Token = string.Empty;
         private static readonly string PhoneNumber = string.Empty;
         private static readonly string Message = "SmsSender works fine";
 
-        private static readonly SmsApiConfiguration Config = new SmsApiConfiguration
+        private static readonly SmsApiConfiguration Config = new(Token, string.Empty)
         {
-            Login = Login,
-            Password = Password,
-            From = string.Empty,
             FastMode = false,
             TestMode = false,
         };
 
-        private static readonly SmsApiConfiguration ConfigWithUnregisteredSender = new SmsApiConfiguration
+        private static readonly SmsApiConfiguration ConfigWithUnregisteredSender = new(Token, Guid.NewGuid().ToString())
         {
-            Login = Login,
-            Password = Password,
-            From = Guid.NewGuid().ToString(),
             FastMode = false,
             TestMode = false,
         };


### PR DESCRIPTION
Attempts to keep some backward compat. Closes #179.