### PR TITLE
Fix profile picture in social logins

### DIFF
--- a/src/Infrastructure/LeanCode.ExternalIdentityProviders/Apple/AppleIdService.cs
+++ b/src/Infrastructure/LeanCode.ExternalIdentityProviders/Apple/AppleIdService.cs
@@ -59,9 +59,8 @@ namespace LeanCode.ExternalIdentityProviders.Apple
                 {
                     var email = token.FindFirst("email")?.Value;
                     var emailConfirmed = token.FindFirst("email_verified")?.Value == "true";
-                    var picture = token.FindFirst("picture")?.Value;
 
-                    return new AppleTokenValidationResult.Success(new(uid, email, emailConfirmed, picture));
+                    return new AppleTokenValidationResult.Success(new(uid, email, emailConfirmed));
                 }
             }
             catch (Exception ex)

--- a/src/Infrastructure/LeanCode.ExternalIdentityProviders/Apple/AppleUser.cs
+++ b/src/Infrastructure/LeanCode.ExternalIdentityProviders/Apple/AppleUser.cs
@@ -1,4 +1,4 @@
 namespace LeanCode.ExternalIdentityProviders.Apple
 {
-    public sealed record AppleUser(string Id, string? Email, bool EmailConfirmed, string? Picture);
+    public sealed record AppleUser(string Id, string? Email, bool EmailConfirmed);
 }

--- a/src/Infrastructure/LeanCode.ExternalIdentityProviders/Facebook/FacebookClient.cs
+++ b/src/Infrastructure/LeanCode.ExternalIdentityProviders/Facebook/FacebookClient.cs
@@ -14,7 +14,7 @@ namespace LeanCode.ExternalIdentityProviders.Facebook
         public const string ApiBase = "https://graph.facebook.com";
         public const string ApiVersion = "v9.0";
 
-        private const string FieldsStr = "id,email,first_name,last_name";
+        private const string FieldsStr = "id,email,first_name,last_name,picture";
 
         private readonly Serilog.ILogger logger = Serilog.Log.ForContext<FacebookClient>();
 
@@ -106,8 +106,9 @@ namespace LeanCode.ExternalIdentityProviders.Facebook
             var firstName = GetOptionalProperty(result, "first_name");
             var lastName = GetOptionalProperty(result, "last_name");
             var photoUrl = $"{ApiBase}/{ApiVersion}/{id}/picture?width={photoSize}&height={photoSize}";
+            var isSilhouette = GetIsSilhouette(result);
 
-            return new FacebookUser(id, email, firstName, lastName, photoUrl);
+            return new FacebookUser(id, email, firstName, lastName, photoUrl, isSilhouette);
 
             static string? GetOptionalProperty(JsonElement element, string propName)
             {
@@ -118,6 +119,20 @@ namespace LeanCode.ExternalIdentityProviders.Facebook
                 else
                 {
                     return null;
+                }
+            }
+
+            static bool GetIsSilhouette(JsonElement element)
+            {
+                if (element.TryGetProperty("picture", out var pic) &&
+                    pic.TryGetProperty("data", out var data) &&
+                    data.TryGetProperty("is_silhouette", out var isSilhouette))
+                {
+                    return isSilhouette.GetBoolean();
+                }
+                else
+                {
+                    return false;
                 }
             }
         }

--- a/src/Infrastructure/LeanCode.ExternalIdentityProviders/Facebook/FacebookUser.cs
+++ b/src/Infrastructure/LeanCode.ExternalIdentityProviders/Facebook/FacebookUser.cs
@@ -7,14 +7,22 @@ namespace LeanCode.ExternalIdentityProviders.Facebook
         public string? FirstName { get; }
         public string? LastName { get; }
         public string Photo { get; }
+        public bool IsSilhouette { get; }
 
-        public FacebookUser(string id, string? email, string? firstName, string? lastName, string photo)
+        public FacebookUser(
+            string id,
+            string? email,
+            string? firstName,
+            string? lastName,
+            string photo,
+            bool isSilhouette)
         {
             Id = id;
             Email = email;
             FirstName = firstName;
             LastName = lastName;
             Photo = photo;
+            IsSilhouette = isSilhouette;
         }
     }
 }


### PR DESCRIPTION
In short - Apple does not include `picture` claim at all (at least according to docs) and we can get if we have a silhouette for FB.