### PR TITLE
Fix sql syntax errors in published events cleaner

### DIFF
--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Inbox/ConsumedMessagesCleaner.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Inbox/ConsumedMessagesCleaner.cs
@@ -39,8 +39,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Inbox
 
                 var deleted = await dbContext.Self.ExecuteScalarAsync<int>(
                     $@"
-                    DELETE t FROM {tableName} t
-                    WHERE t.[DateConsumed] < @time;",
+                    DELETE FROM {tableName}
+                    WHERE [DateConsumed] < @time;",
                     new { time },
                     commandTimeout: 3600,
                     cancellationToken: stoppingToken);

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Outbox/PublishedEventsCleaner.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Outbox/PublishedEventsCleaner.cs
@@ -36,8 +36,8 @@ namespace LeanCode.DomainModels.MassTransitRelay.Outbox
 
                 var count = await outboxContext.Self.ExecuteScalarAsync<int>(
                     $@"
-                    DELETE t FROM {tableName} t WHERE
-                    t.[DateOcurred] < @time AND t.[WasPublished] = 1",
+                    DELETE FROM {tableName} WHERE
+                        [DateOcurred] < @time AND [WasPublished] = 1",
                     new { time },
                     commandTimeout: 3600,
                     cancellationToken: stoppingToken);

--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Outbox/PublishedEventsCleaner.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Outbox/PublishedEventsCleaner.cs
@@ -36,7 +36,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Outbox
 
                 var count = await outboxContext.Self.ExecuteScalarAsync<int>(
                     $@"
-                    DELETE FROM {tableName} t WHERE
+                    DELETE t FROM {tableName} t WHERE
                     t.[DateOcurred] < @time AND t.[WasPublished] = 1",
                     new { time },
                     commandTimeout: 3600,

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Middleware/ConsumedMessagesFilterTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/Middleware/ConsumedMessagesFilterTests.cs
@@ -7,7 +7,6 @@ using Autofac;
 using GreenPipes;
 using LeanCode.DomainModels.MassTransitRelay.Inbox;
 using LeanCode.DomainModels.MassTransitRelay.Middleware;
-using LeanCode.DomainModels.MassTransitRelay.Tests;
 using LeanCode.IdentityProvider;
 using LeanCode.Time;
 using MassTransit;

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/PeriodicActions/ConsumedMessagesCleanerTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/PeriodicActions/ConsumedMessagesCleanerTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using LeanCode.DomainModels.MassTransitRelay.Inbox;
+using LeanCode.Time;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LeanCode.DomainModels.MassTransitRelay.Tests.PeriodicActions
+{
+    public class ConsumedMessagesCleanerTests : DbTestBase
+    {
+        private static readonly DateTime Now = new(2021, 4, 13, 12, 0, 0);
+        private readonly ConsumedMessagesCleaner cleaner;
+
+        public ConsumedMessagesCleanerTests()
+        {
+            FixedTimeProvider.SetTo(Now);
+            cleaner = new(DbContext);
+        }
+
+        [Fact]
+        public async Task Removes_old_consumed_message_entry()
+        {
+            var msgId = await PrepareConsumedMessageAsync(Now.AddDays(-5));
+
+            await cleaner.ExecuteAsync(default);
+
+            Assert.False(await ExistsAsync(msgId));
+        }
+
+        [Fact]
+        public async Task Does_not_remove_fresh_consumed_message_entry()
+        {
+            var msgId = await PrepareConsumedMessageAsync(Now.AddMinutes(-5));
+
+            await cleaner.ExecuteAsync(default);
+
+            Assert.True(await ExistsAsync(msgId));
+        }
+
+        private Task<bool> ExistsAsync(Guid msgId) => DbContext.ConsumedMessages.AnyAsync(m => m.MessageId == msgId);
+
+        private async Task<Guid> PrepareConsumedMessageAsync(DateTime dateConsumed)
+        {
+            var msg = new ConsumedMessage(Guid.NewGuid(), dateConsumed, "TestConsumer", "TestMessage");
+
+            DbContext.ConsumedMessages.Add(msg);
+            await DbContext.SaveChangesAsync();
+
+            return msg.MessageId;
+        }
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/PeriodicActions/DbTestBase.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/PeriodicActions/DbTestBase.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace LeanCode.DomainModels.MassTransitRelay.Tests.PeriodicActions
+{
+    public abstract class DbTestBase : IAsyncLifetime, IDisposable
+    {
+        protected TestDbContext DbContext { get; }
+        private readonly DbConnection dbConnection;
+
+        protected DbTestBase()
+        {
+            dbConnection = new SqliteConnection("Filename=:memory:");
+            DbContext = TestDbContext.Create(dbConnection);
+        }
+
+        public async Task InitializeAsync()
+        {
+            // harness started at test level because
+            // we need to have different consumers in each test
+            // await harness.Start();
+
+            await dbConnection.OpenAsync();
+            await DbContext.Database.EnsureCreatedAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await dbConnection.CloseAsync();
+            await dbConnection.DisposeAsync();
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/PeriodicActions/PublishedEventsCleanerTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/PeriodicActions/PublishedEventsCleanerTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using LeanCode.DomainModels.MassTransitRelay.Outbox;
+using LeanCode.Time;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LeanCode.DomainModels.MassTransitRelay.Tests.PeriodicActions
+{
+    public class PublishedEventsCleanerTests : DbTestBase
+    {
+        private static readonly DateTime Now = new(2021, 4, 13, 12, 0, 0);
+        private readonly PublishedEventsCleaner cleaner;
+
+        public PublishedEventsCleanerTests()
+        {
+            FixedTimeProvider.SetTo(Now);
+            cleaner = new(DbContext);
+        }
+
+        [Fact]
+        public async Task Removes_old_published_events()
+        {
+            var eventId = await PrepareRaisedEventAsync(Now.AddDays(-7), true);
+
+            await cleaner.ExecuteAsync(default);
+
+            await AssertDoesNotExistAsync(eventId);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Does_not_remove_fresh_published_and_unpublished_events(bool wasPublished)
+        {
+            var eventId = await PrepareRaisedEventAsync(Now.AddMinutes(-5), wasPublished);
+
+            await cleaner.ExecuteAsync(default);
+
+            await AssertExistsAsync(eventId);
+        }
+
+        [Fact]
+        public async Task Does_not_remove_old_unpublished_events()
+        {
+            var eventId = await PrepareRaisedEventAsync(Now.AddDays(-5), false);
+
+            await cleaner.ExecuteAsync(default);
+
+            await AssertExistsAsync(eventId);
+        }
+
+        private async Task AssertDoesNotExistAsync(Guid eventId)
+        {
+            var r = await DbContext.RaisedEvents.AnyAsync(e => e.Id == eventId);
+            Assert.False(r);
+        }
+
+        private async Task AssertExistsAsync(Guid eventId)
+        {
+            var r = await DbContext.RaisedEvents.AnyAsync(e => e.Id == eventId);
+            Assert.True(r);
+        }
+
+        private async Task<Guid> PrepareRaisedEventAsync(DateTime dateOccurred, bool wasPublished)
+        {
+            var evt = new RaisedEvent(Guid.NewGuid(), new(), dateOccurred, wasPublished, "TestEventType", "{}");
+
+            DbContext.RaisedEvents.Add(evt);
+            await DbContext.SaveChangesAsync();
+
+            return evt.Id;
+        }
+    }
+}


### PR DESCRIPTION
I remember this was fixed before, must have been reintroduced when merging open telemetry :disappointed: 