### PR TITLE
Suppress SA1122 rule, use "" instead of `string.Empty` everywhere

### DIFF
--- a/LeanCode.CodeAnalysis.ruleset
+++ b/LeanCode.CodeAnalysis.ruleset
@@ -26,6 +26,8 @@
         <!-- ParametersMustBeOnSameLineOrSeparateLines -->
         <Rule Id="SA1118" Action="None"/>
         <!-- ParameterMustNotSpanMultipleLines -->
+        <Rule Id="SA1122" Action="None"/>
+        <!-- UseStringEmptyForEmptyStrings -->
         <Rule Id="SA1129" Action="None"/>
         <!-- DoNotUseDefaultValueTypeConstructor -->
 

--- a/src/Domain/LeanCode.CQRS.RemoteHttp.Client/HttpCommandsExecutor.cs
+++ b/src/Domain/LeanCode.CQRS.RemoteHttp.Client/HttpCommandsExecutor.cs
@@ -81,8 +81,8 @@ namespace LeanCode.CQRS.RemoteHttp.Client
                 propName.ValueKind == JsonValueKind.String)
             {
                 return new ValidationError(
-                    propName.GetString() ?? string.Empty,
-                    errMsg.GetString() ?? string.Empty,
+                    propName.GetString() ?? "",
+                    errMsg.GetString() ?? "",
                     errCode.GetInt32());
             }
             else

--- a/src/Infrastructure/LeanCode.ClientCredentialsHandler/ClientCredentialsConfiguration.cs
+++ b/src/Infrastructure/LeanCode.ClientCredentialsHandler/ClientCredentialsConfiguration.cs
@@ -2,9 +2,9 @@ namespace LeanCode.ClientCredentialsHandler
 {
     public class ClientCredentialsConfiguration
     {
-        public string ServerAddress { get; set; } = string.Empty;
-        public string ClientId { get; set; } = string.Empty;
-        public string ClientSecret { get; set; } = string.Empty;
-        public string Scopes { get; set; } = string.Empty;
+        public string ServerAddress { get; set; } = "";
+        public string ClientId { get; set; } = "";
+        public string ClientSecret { get; set; } = "";
+        public string Scopes { get; set; } = "";
     }
 }

--- a/src/Infrastructure/LeanCode.Dapper/RawQueryValidator.cs
+++ b/src/Infrastructure/LeanCode.Dapper/RawQueryValidator.cs
@@ -27,7 +27,7 @@ namespace LeanCode.Dapper
             {
                 try
                 {
-                    var sqlText = (string?)sql.GetValue(null) ?? string.Empty;
+                    var sqlText = (string?)sql.GetValue(null) ?? "";
 
                     // https://xkcd.com/208/
                     sqlText = Regex.Replace(sqlText, "IN @[a-zA-Z]{0,}", "IN (1)", RegexOptions.Compiled);

--- a/src/Infrastructure/LeanCode.ExternalIdentityProviders/ExternalLoginExceptionHandler.cs
+++ b/src/Infrastructure/LeanCode.ExternalIdentityProviders/ExternalLoginExceptionHandler.cs
@@ -27,17 +27,17 @@ namespace LeanCode.ExternalIdentityProviders
                 ValidationError err = ex.TokenValidation switch
                 {
                     TokenValidationError.Invalid => new(
-                        string.Empty,
+                        "",
                         "The token is invalid.",
                         ErrorCodeInvalidToken),
 
                     TokenValidationError.OtherConnected => new(
-                        string.Empty,
+                        "",
                         "Other account is already connected with this token.",
                         ErrorCodeOtherConnected),
 
                     _ => new(
-                        string.Empty,
+                        "",
                         "Cannot perform external login.",
                         ErrorCodeOther),
                 };

--- a/src/Infrastructure/LeanCode.ExternalIdentityProviders/Facebook/FacebookClient.cs
+++ b/src/Infrastructure/LeanCode.ExternalIdentityProviders/Facebook/FacebookClient.cs
@@ -142,7 +142,7 @@ namespace LeanCode.ExternalIdentityProviders.Facebook
             if (hmac is null)
             {
                 logger.Error("Facebook's AppSecret is not configured, login with Facebook will fail");
-                return string.Empty;
+                return "";
             }
             else
             {
@@ -157,7 +157,7 @@ namespace LeanCode.ExternalIdentityProviders.Facebook
             Encoding.ASCII.GetBytes(v);
 
         private static string ToHexString(byte[] data) =>
-            BitConverter.ToString(data).Replace("-", string.Empty).ToLower();
+            BitConverter.ToString(data).Replace("-", "").ToLower();
 
         private static string AppendProof(string uri, string accessToken, string proof)
         {

--- a/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenEntity.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/EntityFramework/PushNotificationTokenEntity.cs
@@ -7,7 +7,7 @@ namespace LeanCode.Firebase.FCM.EntityFramework
     {
         public Guid Id { get; set; }
         public Guid UserId { get; set; }
-        public string Token { get; set; } = string.Empty;
+        public string Token { get; set; } = "";
         public DateTime DateCreated { get; set; }
 
         public static void Configure(ModelBuilder builder)

--- a/src/Infrastructure/LeanCode.IdentityServer.KeyVault/IdentityServerKeyVaultConfiguration.cs
+++ b/src/Infrastructure/LeanCode.IdentityServer.KeyVault/IdentityServerKeyVaultConfiguration.cs
@@ -2,9 +2,9 @@ namespace LeanCode.IdentityServer.KeyVault
 {
     public class IdentityServerKeyVaultConfiguration
     {
-        public string ClientId { get; set; } = string.Empty;
-        public string ClientSecret { get; set; } = string.Empty;
-        public string KeyId { get; set; } = string.Empty;
-        public string TenantId { get; set; } = string.Empty;
+        public string ClientId { get; set; } = "";
+        public string ClientSecret { get; set; } = "";
+        public string KeyId { get; set; } = "";
+        public string TenantId { get; set; } = "";
     }
 }

--- a/src/Infrastructure/LeanCode.Mixpanel/MixpanelConfiguration.cs
+++ b/src/Infrastructure/LeanCode.Mixpanel/MixpanelConfiguration.cs
@@ -2,8 +2,8 @@ namespace LeanCode.Mixpanel
 {
     public class MixpanelConfiguration
     {
-        public string Token { get; set; } = string.Empty;
-        public string ApiKey { get; set; } = string.Empty;
+        public string Token { get; set; } = "";
+        public string ApiKey { get; set; } = "";
         public bool VerboseErrors { get; set; }
     }
 }

--- a/src/Infrastructure/LeanCode.PdfRocket/PdfRocketConfiguration.cs
+++ b/src/Infrastructure/LeanCode.PdfRocket/PdfRocketConfiguration.cs
@@ -2,6 +2,6 @@ namespace LeanCode.PdfRocket
 {
     public class PdfRocketConfiguration
     {
-        public string ApiKey { get; set; } = string.Empty;
+        public string ApiKey { get; set; } = "";
     }
 }

--- a/src/Infrastructure/LeanCode.SmsSender/SmsApiConfiguration.cs
+++ b/src/Infrastructure/LeanCode.SmsSender/SmsApiConfiguration.cs
@@ -10,9 +10,9 @@ namespace LeanCode.SmsSender
     public class SmsApiConfiguration // TODO: change to some immutable record
     {
         public string? Token { get; set; }
-        public string Login { get; set; } = string.Empty;
-        public string Password { get; set; } = string.Empty;
-        public string From { get; set; } = string.Empty;
+        public string Login { get; set; } = "";
+        public string Password { get; set; } = "";
+        public string From { get; set; } = "";
         public bool FastMode { get; set; }
         public bool TestMode { get; set; }
 

--- a/src/Infrastructure/LeanCode.ViewRenderer.Razor/ViewLocator.cs
+++ b/src/Infrastructure/LeanCode.ViewRenderer.Razor/ViewLocator.cs
@@ -73,9 +73,9 @@ namespace LeanCode.ViewRenderer.Razor
 
             public Item(string path)
             {
-                BasePath = string.Empty;
+                BasePath = "";
                 FilePath = path;
-                PhysicalPath = string.Empty;
+                PhysicalPath = "";
                 Exists = false;
             }
 

--- a/src/Tools/LeanCode.ContractsGenerator/CodeGenerator.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/CodeGenerator.cs
@@ -322,7 +322,7 @@ namespace LeanCode.ContractsGenerator
                         {
                             Name = type.Name,
                             ParentChain = GetTypeParentChain(type),
-                            Namespace = type is ITypeParameterSymbol ? string.Empty : GetFullNamespaceName(type.ContainingNamespace),
+                            Namespace = type is ITypeParameterSymbol ? "" : GetFullNamespaceName(type.ContainingNamespace),
                             TypeArguments = type.TypeArguments.Select(ConvertType).ToList(),
                         };
                     }
@@ -366,7 +366,7 @@ namespace LeanCode.ContractsGenerator
         {
             if (info == null)
             {
-                return string.Empty;
+                return "";
             }
             else if (info.ContainingNamespace == null || info.ContainingNamespace.IsGlobalNamespace)
             {

--- a/src/Tools/LeanCode.ContractsGenerator/Extensions/StringBuilderExtensions.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Extensions/StringBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace LeanCode.ContractsGenerator.Extensions
     {
         public static StringBuilder AppendSpaces(this StringBuilder builder, int level)
         {
-            return builder.Append(string.Join(string.Empty, Enumerable.Repeat("    ", level)));
+            return builder.Append(string.Join("", Enumerable.Repeat("    ", level)));
         }
     }
 }

--- a/src/Tools/LeanCode.ContractsGenerator/GeneratorConfiguration.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/GeneratorConfiguration.cs
@@ -14,7 +14,7 @@ namespace LeanCode.ContractsGenerator
         public string ContractsRegex { get; set; } = @".*\.cs$";
         public string OutPath { get; set; } = Directory.GetCurrentDirectory();
         public string Name { get; set; } = "contracts";
-        public string AdditionalCode { get; set; } = string.Empty;
+        public string AdditionalCode { get; set; } = "";
         public string ErrorCodesName { get; set; } = "ErrorCodes";
 
         public TypeScriptConfiguration? TypeScript { get; set; }

--- a/src/Tools/LeanCode.ContractsGenerator/Languages/Dart/DartConfiguration.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Languages/Dart/DartConfiguration.cs
@@ -12,7 +12,7 @@ namespace LeanCode.ContractsGenerator.Languages.Dart
             "part '{0}.g.dart';",
             "abstract class IRemoteQuery<T> extends Query<T> {{}}",
             "abstract class IRemoteCommand extends Command {{}}",
-            string.Empty,
+            "",
         };
 
         public static string DefaultContractsPreamble => string.Join('\n', DefaultPreambleLines);

--- a/src/Tools/LeanCode.ContractsGenerator/Languages/Dart/DartVisitor.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Languages/Dart/DartVisitor.cs
@@ -581,7 +581,7 @@ namespace LeanCode.ContractsGenerator.Languages.Dart
         private static string MakeName(string namespaceName, string name, int depth)
         {
             var split = namespaceName.Split('.').Reverse().Take(depth).Append(name);
-            return string.Join(string.Empty, split);
+            return string.Join("", split);
         }
 
         private static string TranslateIdentifier(string identifier)

--- a/src/Tools/LeanCode.ContractsGenerator/Languages/TypeScript/TypeScriptConfiguration.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Languages/TypeScript/TypeScriptConfiguration.cs
@@ -10,7 +10,7 @@ namespace LeanCode.ContractsGenerator.Languages.TypeScript
             "import { ClientType } from \"@leancode/cqrs-client/ClientType\";",
             "import { CQRS } from \"@leancode/cqrs-client/CQRS\";",
             "import { IRemoteCommand, IRemoteQuery } from \"@leancode/cqrs-client/ClientType\";",
-            string.Empty,
+            "",
         };
 
         public string? ContractsPreamble

--- a/src/Tools/LeanCode.ContractsGenerator/Statements/ClientStatement.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Statements/ClientStatement.cs
@@ -5,6 +5,6 @@ namespace LeanCode.ContractsGenerator.Statements
     internal class ClientStatement : IStatement
     {
         public List<IStatement> Children { get; set; } = new List<IStatement>();
-        public string Name { get; set; } = string.Empty;
+        public string Name { get; set; } = "";
     }
 }

--- a/src/Tools/LeanCode.ContractsGenerator/Statements/ConstStatement.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Statements/ConstStatement.cs
@@ -2,7 +2,7 @@ namespace LeanCode.ContractsGenerator.Statements
 {
     internal class ConstStatement : IStatement
     {
-        public string Name { get; set; } = string.Empty;
+        public string Name { get; set; } = "";
         public string? Value { get; set; }
     }
 }

--- a/src/Tools/LeanCode.ContractsGenerator/Statements/EnumStatement.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Statements/EnumStatement.cs
@@ -4,8 +4,8 @@ namespace LeanCode.ContractsGenerator.Statements
 {
     internal class EnumStatement : INamespacedStatement
     {
-        public string Name { get; set; } = string.Empty;
-        public string Namespace { get; set; } = string.Empty;
+        public string Name { get; set; } = "";
+        public string Namespace { get; set; } = "";
         public List<EnumValueStatement> Values { get; set; } = new List<EnumValueStatement>();
     }
 }

--- a/src/Tools/LeanCode.ContractsGenerator/Statements/EnumValueStatement.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Statements/EnumValueStatement.cs
@@ -2,7 +2,7 @@ namespace LeanCode.ContractsGenerator.Statements
 {
     internal class EnumValueStatement : IStatement
     {
-        public string Name { get; set; } = string.Empty;
-        public string? Value { get; set; } = string.Empty;
+        public string Name { get; set; } = "";
+        public string? Value { get; set; } = "";
     }
 }

--- a/src/Tools/LeanCode.ContractsGenerator/Statements/InterfaceStatement.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Statements/InterfaceStatement.cs
@@ -4,11 +4,11 @@ namespace LeanCode.ContractsGenerator.Statements
 {
     internal class InterfaceStatement : INamespacedStatement
     {
-        public string Name { get; set; } = string.Empty;
+        public string Name { get; set; } = "";
         public bool IsStatic { get; set; }
         public bool IsClass { get; set; }
         public TypeStatement? BaseClass { get; set; }
-        public string Namespace { get; set; } = string.Empty;
+        public string Namespace { get; set; } = "";
         public List<InterfaceStatement> ParentChain { get; set; } = new List<InterfaceStatement>();
         public List<TypeParameterStatement> Parameters { get; set; } = new List<TypeParameterStatement>();
         public List<TypeStatement> Extends { get; set; } = new List<TypeStatement>();

--- a/src/Tools/LeanCode.ContractsGenerator/Statements/TypeParameterStatement.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Statements/TypeParameterStatement.cs
@@ -4,7 +4,7 @@ namespace LeanCode.ContractsGenerator.Statements
 {
     internal class TypeParameterStatement : IStatement
     {
-        public string Name { get; set; } = string.Empty;
+        public string Name { get; set; } = "";
         public List<TypeStatement> Constraints { get; set; } = new List<TypeStatement>();
     }
 }

--- a/src/Tools/LeanCode.ContractsGenerator/Statements/TypeStatement.cs
+++ b/src/Tools/LeanCode.ContractsGenerator/Statements/TypeStatement.cs
@@ -4,8 +4,8 @@ namespace LeanCode.ContractsGenerator.Statements
 {
     internal class TypeStatement : INamespacedStatement
     {
-        public string Name { get; set; } = string.Empty;
-        public string Namespace { get; set; } = string.Empty;
+        public string Name { get; set; } = "";
+        public string Namespace { get; set; } = "";
         public bool IsDictionary { get; set; }
         public bool IsNullable { get; set; }
         public bool IsArrayLike { get; set; }

--- a/test/Core/LeanCode.Time.Tests/DateFormattingTests.cs
+++ b/test/Core/LeanCode.Time.Tests/DateFormattingTests.cs
@@ -75,7 +75,7 @@ namespace System._Time.Tests
         public void ToStringWithEmptyDateFormat()
         {
             var date = new Date(2000, 12, 31);
-            var s = date.ToString(string.Empty);
+            var s = date.ToString("");
             Assert.Equal("12/31/2000", s);
         }
 

--- a/test/Core/LeanCode.Time.Tests/TimeFormattingTests.cs
+++ b/test/Core/LeanCode.Time.Tests/TimeFormattingTests.cs
@@ -67,7 +67,7 @@ namespace System._Time.Tests
         public void ToStringWithEmptyTimeFormat()
         {
             var time = new Time(23, 59, 59);
-            var s = time.ToString(string.Empty);
+            var s = time.ToString("");
             Assert.Equal("23:59:59", s);
         }
 

--- a/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/HttpCommandsExecutorTests.cs
+++ b/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/HttpCommandsExecutorTests.cs
@@ -143,7 +143,7 @@ namespace LeanCode.CQRS.RemoteHttp.Client.Tests
         private static async Task TestExceptionAsync<TException>(HttpStatusCode statusCode)
             where TException : Exception
         {
-            var (exec, _) = Prepare(statusCode, string.Empty);
+            var (exec, _) = Prepare(statusCode, "");
 
             await Assert.ThrowsAsync<TException>(() => exec.RunAsync(new ExampleCommand()));
         }

--- a/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/HttpQueriesExecutorTests.cs
+++ b/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/HttpQueriesExecutorTests.cs
@@ -101,7 +101,7 @@ namespace LeanCode.CQRS.RemoteHttp.Client.Tests
         private static async Task TestExceptionAsync<TException>(HttpStatusCode statusCode)
             where TException : Exception
         {
-            var (exec, _) = Prepare(statusCode, string.Empty);
+            var (exec, _) = Prepare(statusCode, "");
 
             await Assert.ThrowsAsync<TException>(() => exec.GetAsync(new ExampleQuery()));
         }

--- a/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/ShortcircuitingJsonHandler.cs
+++ b/test/Domain/LeanCode.CQRS.RemoteHttp.Client.Tests/ShortcircuitingJsonHandler.cs
@@ -11,7 +11,7 @@ namespace LeanCode.CQRS.RemoteHttp.Client.Tests
     internal class ShortcircuitingJsonHandler : HttpMessageHandler
     {
         private readonly HttpStatusCode statusCode = HttpStatusCode.OK;
-        private readonly string response = string.Empty;
+        private readonly string response = "";
 
         public HttpRequestMessage? Request { get; set; }
 

--- a/test/Domain/LeanCode.CQRS.RemoteHttp.Server.Tests/StubContext.cs
+++ b/test/Domain/LeanCode.CQRS.RemoteHttp.Server.Tests/StubContext.cs
@@ -67,7 +67,7 @@ namespace LeanCode.CQRS.RemoteHttp.Server.Tests
             ContentLength = bytes.Length;
 
             Query = new QueryCollection();
-            Protocol = string.Empty;
+            Protocol = "";
         }
 
         public override IHeaderDictionary Headers => throw new NotImplementedException();

--- a/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/JsonEventsSerializerTests.cs
+++ b/test/Domain/LeanCode.DomainModels.MassTransitRelay.Tests/JsonEventsSerializerTests.cs
@@ -109,7 +109,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Tests
 
             private TestEventWithPrivateFields()
             {
-                Value = string.Empty;
+                Value = "";
             }
         }
     }

--- a/test/Domain/LeanCode.DomainModels.Tests/ValueObjectTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/ValueObjectTests.cs
@@ -78,7 +78,7 @@ namespace LeanCode.DomainModels.Tests
         private record Money : ValueObject
         {
             public decimal Amount { get; private init; }
-            public string Currency { get; private init; } = string.Empty;
+            public string Currency { get; private init; } = "";
 
             public Money(decimal amount, string currency)
             {

--- a/test/Infrastructure/LeanCode.ExternalIdentityProviders.Tests/ExternalLoginGrantValidatorTests.cs
+++ b/test/Infrastructure/LeanCode.ExternalIdentityProviders.Tests/ExternalLoginGrantValidatorTests.cs
@@ -30,7 +30,7 @@ namespace LeanCode.ExternalIdentityProviders.Tests
         [Fact]
         public async Task Passing_empty_token_results_in_no_assertion_error()
         {
-            var res = await ValidateAsync(string.Empty);
+            var res = await ValidateAsync("");
 
             res.AssertInvalid("no_assertion");
         }

--- a/test/Infrastructure/LeanCode.ExternalIdentityProviders.Tests/Facebook/FacebookClientTests.cs
+++ b/test/Infrastructure/LeanCode.ExternalIdentityProviders.Tests/Facebook/FacebookClientTests.cs
@@ -9,8 +9,8 @@ namespace LeanCode.ExternalIdentityProviders.Tests.Facebook
 {
     public class FacebookClientTests
     {
-        private static readonly FacebookConfiguration Config = new(Environment.GetEnvironmentVariable("FACEBOOK_APP_SECRET") ?? string.Empty);
-        private static readonly string AccessToken = Environment.GetEnvironmentVariable("FACEBOOK_TOKEN") ?? string.Empty;
+        private static readonly FacebookConfiguration Config = new(Environment.GetEnvironmentVariable("FACEBOOK_APP_SECRET") ?? "");
+        private static readonly string AccessToken = Environment.GetEnvironmentVariable("FACEBOOK_TOKEN") ?? "";
 
         private readonly FacebookClient client;
 

--- a/test/Infrastructure/LeanCode.PdfRocket/PdfRocketGeneratorTests.cs
+++ b/test/Infrastructure/LeanCode.PdfRocket/PdfRocketGeneratorTests.cs
@@ -8,7 +8,7 @@ namespace LeanCode.PdfRocket.Tests
 {
     public class PdfRocketGeneratorTests
     {
-        private static readonly string ApiKey = Environment.GetEnvironmentVariable("PDF_ROCKET_API_KEY") ?? string.Empty;
+        private static readonly string ApiKey = Environment.GetEnvironmentVariable("PDF_ROCKET_API_KEY") ?? "";
 
         internal class PdfRocketFactAttribute : FactAttribute
         {

--- a/test/Infrastructure/LeanCode.SmsSender.Tests/SmsSenderClientTests.cs
+++ b/test/Infrastructure/LeanCode.SmsSender.Tests/SmsSenderClientTests.cs
@@ -12,7 +12,7 @@ namespace LeanCode.SmsSender.Tests
         private static readonly string PhoneNumber = Environment.GetEnvironmentVariable("SMSAPI_PHONENUMBERTO");
         private static readonly string Message = "SmsSender works fine";
 
-        private static readonly SmsApiConfiguration Config = new(Token, string.Empty)
+        private static readonly SmsApiConfiguration Config = new(Token, "")
         {
             FastMode = false,
             TestMode = false,

--- a/test/LeanCode.IntegrationTests/TestApp.cs
+++ b/test/LeanCode.IntegrationTests/TestApp.cs
@@ -35,7 +35,7 @@ namespace LeanCode.IntegrationTests
                 Scope = "profile openid api",
 
                 ClientId = "web",
-                ClientSecret = string.Empty,
+                ClientSecret = "",
             });
         }
 

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.TypesGeneration.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/Dart/ContractsGeneratorTests.TypesGeneration.cs
@@ -9,7 +9,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
         [Fact]
         public void Imports_are_generated()
         {
-            var generator = CreateDartGeneratorFromClass(string.Empty);
+            var generator = CreateDartGeneratorFromClass("");
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
@@ -20,7 +20,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
         [Fact]
         public void Part_uses_name_from_generator_configuration_for_default_preamble()
         {
-            var generator = CreateDartGeneratorFromClass(string.Empty);
+            var generator = CreateDartGeneratorFromClass("");
             var cfg = new GeneratorConfiguration()
             {
                 Name = "Name",
@@ -37,7 +37,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
         [Fact]
         public void List_helper_is_generated()
         {
-            var generator = CreateDartGeneratorFromClass(string.Empty);
+            var generator = CreateDartGeneratorFromClass("");
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
@@ -47,7 +47,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
         [Fact]
         public void DateTime_helpers_is_generated()
         {
-            var generator = CreateDartGeneratorFromClass(string.Empty);
+            var generator = CreateDartGeneratorFromClass("");
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 
@@ -58,7 +58,7 @@ namespace LeanCode.ContractsGenerator.Tests.Dart
         [Fact]
         public void Double_helpers_is_generated()
         {
-            var generator = CreateDartGeneratorFromClass(string.Empty);
+            var generator = CreateDartGeneratorFromClass("");
 
             var contracts = GetContracts(generator.Generate(DefaultDartConfiguration));
 

--- a/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTestHelpers.cs
+++ b/test/Tools/LeanCode.ContractsGenerator.Tests/TypeScript/ContractsGeneratorTestHelpers.cs
@@ -36,7 +36,7 @@ namespace LeanCode.ContractsGenerator.Tests.TypeScript
             Name = "Test",
             TypeScript = new TypeScriptConfiguration
             {
-                ContractsPreamble = string.Empty,
+                ContractsPreamble = "",
             },
         };
 


### PR DESCRIPTION
Closes #282