### PR TITLE
Remove `RowVersion` property from `IOptimisticConcurrency` interface

### DIFF
--- a/docs/adrs/2021-11-25_optimistic_concurrency.md
+++ b/docs/adrs/2021-11-25_optimistic_concurrency.md
@@ -1,0 +1,42 @@
+# How to handle concurrency token columns in non–MSSQL databases
+
+The `IOptimisticConcurrency` interface requires `DateTime DateModified` and `byte[] RowVersion` properties to be implemented by aggregate roots. However, the `byte[]` representation of `RowVersion` column is specific to Microsoft SQL Server and is not compatible with other databases, such as PostgreSQL and its convention to use `uint xmin` hidden column as a concurrency token.
+
+## Status
+
+Implemented (2021-12-06)
+
+## Context
+
+Until now, MSSQL was the only SQL database supported by CoreLib. This issue came up when we attempted to replace MSSQL Server with PostgreSQL in one of the projects.
+
+We have considered two solutions to this problem: marking the existing interface as MSSQL–specific (plus perhaps introducing new ones for other databases) and removing `byte[] RowVersion` from the interface (keeping only `DateTime DateModified` with any row version properties staying only in shadow state).
+
+## Decision
+
+We have chosen to remove `byte[] RowVersion` from the interface and update builder methods like `IsOptimisticConcurrent` to optionally configure `byte[] RowVersion` as a shadow property. This allowed us to minimize pollution of domain interfaces with implementation–specific solutions that should have minimal impact on this layer.
+
+## Consequences
+
+* Project updating from previous versions will have to remove implementations of `byte[] IOptimisticConcurrency.RowVersion` property from aggregate roots. Updated builder methods will keep that property in shadow state, making migrations unnecessary.
+* Having a property in shadow state will prevent tracked aggregate instances from being shared with other `DbContext`s. We consider this to be an upside :)
+
+## Side notes
+
+### How to use `IOptimisticConcurrency` with MSSQL
+
+* Implement `IAggregateRoot` in your aggregate root entity as normal. Prefer using explicit interface implementation for `DateTime IOptimisticConcurrency.DateModified` to hide public setter from code that shouldn't use it.
+* Configure your entity in `DbContext`'s `OnConfiguring` method like so:
+
+```csharp
+builder.Entity<Foo>().IsOptimisticConcurrent(addRowVersion: true /* the default, can be omitted */);
+```
+
+### How to use `IOptimisticConcurrency` with Npgsql
+
+* Implement `IAggregateRoot` in your aggregate root entity as normal. Prefer using explicit interface implementation for `DateTime IOptimisticConcurrency.DateModified` to hide public setter from code that shouldn't use it.
+* Configure your entity in `DbContext`'s `OnConfiguring` method like so:
+
+```csharp
+builder.Entity<Foo>().UseXminAsConcurrencyToken().IsOptimisticConcurrent(addRowVersion: false);
+```

--- a/src/Domain/LeanCode.DomainModels/Model/IOptimisticConcurrency.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/IOptimisticConcurrency.cs
@@ -4,8 +4,6 @@ namespace LeanCode.DomainModels.Model
 {
     public interface IOptimisticConcurrency
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("?", "CA1819", Justification = "Required by EFCore.")]
-        byte[] RowVersion { get; set; }
         DateTime DateModified { get; set; }
     }
 }

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/ModelBuilderExtensionsTests.OptimisticConcurrency.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/ModelBuilderExtensionsTests.OptimisticConcurrency.cs
@@ -9,17 +9,6 @@ namespace LeanCode.DomainModels.EF.Tests
     public class ModelBuilderExtensionsTests_OptimisticConcurrency
     {
         [Fact]
-        public void When_IOC_is_implemented_explicitly_RowVersion_has_correctly_configured_backing_field()
-        {
-            using (var db = new ExplicitlyContext())
-            {
-                var ent = db.Model.FindEntityType(typeof(ExplicitlyImplemented).FullName);
-                var prop = ent.FindProperty("RowVersion");
-                Assert.Equal("<LeanCode.DomainModels.Model.IOptimisticConcurrency.RowVersion>k__BackingField", prop.FieldInfo.Name);
-            }
-        }
-
-        [Fact]
         public void When_IOC_is_implemented_explicitly_DateModified_has_correctly_configured_backing_field()
         {
             using (var db = new ExplicitlyContext())
@@ -31,17 +20,6 @@ namespace LeanCode.DomainModels.EF.Tests
         }
 
         [Fact]
-        public void When_IOC_is_implemented_implicitly_RowVersion_has_correctly_configured_backing_field()
-        {
-            using (var db = new ImplicitlyContext())
-            {
-                var ent = db.Model.FindEntityType(typeof(ImplicitlyImplemented).FullName);
-                var prop = ent.FindProperty("RowVersion");
-                Assert.Equal("<RowVersion>k__BackingField", prop.FieldInfo.Name);
-            }
-        }
-
-        [Fact]
         public void When_IOC_is_implemented_implicitly_DateModified_has_correctly_configured_backing_field()
         {
             using (var db = new ImplicitlyContext())
@@ -49,15 +27,6 @@ namespace LeanCode.DomainModels.EF.Tests
                 var ent = db.Model.FindEntityType(typeof(ImplicitlyImplemented).FullName);
                 var prop = ent.FindProperty("DateModified");
                 Assert.Equal("<DateModified>k__BackingField", prop.FieldInfo.Name);
-            }
-        }
-
-        [Fact]
-        public void When_RowVersion_is_implemented_differently_Fails()
-        {
-            using (var db = new WrongRowVersionContext())
-            {
-                Assert.Throws<InvalidOperationException>(() => db.Model.FindEntityType(typeof(WrongRowVersion).FullName));
             }
         }
 
@@ -74,7 +43,6 @@ namespace LeanCode.DomainModels.EF.Tests
     public class ExplicitlyImplemented : IOptimisticConcurrency
     {
         public int Id { get; set; }
-        byte[] IOptimisticConcurrency.RowVersion { get; set; }
         DateTime IOptimisticConcurrency.DateModified { get; set; }
     }
 
@@ -94,8 +62,6 @@ namespace LeanCode.DomainModels.EF.Tests
     public class ImplicitlyImplemented : IOptimisticConcurrency
     {
         public int Id { get; set; }
-        [SuppressMessage("?", "CA1819", Justification = "Convention.")]
-        public byte[] RowVersion { get; set; }
         public DateTime DateModified { get; set; }
     }
 
@@ -113,37 +79,11 @@ namespace LeanCode.DomainModels.EF.Tests
     }
 
     [SuppressMessage("?", "IDE0032", Justification = "Specifically for tests.")]
-    public class WrongRowVersion : IOptimisticConcurrency
-    {
-        private byte[] rowVersion;
-
-        public int Id { get; set; }
-        [SuppressMessage("?", "CA1819", Justification = "Convention.")]
-        public byte[] RowVersion { get => rowVersion; set => rowVersion = value; }
-        public DateTime DateModified { get; set; }
-    }
-
-    public class WrongRowVersionContext : DbContext
-    {
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString("N"));
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.EnableOptimisticConcurrency<WrongRowVersion>();
-        }
-    }
-
-    [SuppressMessage("?", "IDE0032", Justification = "Specifically for tests.")]
     public class WrongDateModified : IOptimisticConcurrency
     {
         private DateTime dateModified;
 
         public int Id { get; set; }
-        [SuppressMessage("?", "CA1819", Justification = "Convention.")]
-        public byte[] RowVersion { get; set; }
         public DateTime DateModified { get => dateModified; set => dateModified = value; }
     }
 

--- a/test/Domain/LeanCode.DomainModels.Tests/IRepositoryExtensionsTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/IRepositoryExtensionsTests.cs
@@ -67,7 +67,6 @@ namespace LeanCode.DomainModels.Tests
     {
         public Id<DiscountCode> Id { get; set; }
 
-        byte[] IOptimisticConcurrency.RowVersion { get; set; } = null!;
         DateTime IOptimisticConcurrency.DateModified { get; set; }
     }
 
@@ -75,7 +74,6 @@ namespace LeanCode.DomainModels.Tests
     {
         public int Id { get; set; }
 
-        byte[] IOptimisticConcurrency.RowVersion { get; set; } = null!;
         DateTime IOptimisticConcurrency.DateModified { get; set; }
     }
 }


### PR DESCRIPTION
It's now an optional shadow property.

As discussed last week. The other overload is for when the database used something other than `byte[]` as the type for row version column.

When using Npgsql we can now configure aggregates like so:

```csharp
builder.Entity<Foo>().UseXminAsConcurrencyToken().IsOptimisticConcurrent(addRowVersion: false);
```

Fwiw I believe these methods should return the builder so multiple calls can be chained, but I don't care that much.

Btw, do we need an ADR here?