### PR TITLE
Add custom `JsonConverter`s for `DateOnly` and `TimeOnly`

### DIFF
--- a/src/Domain/LeanCode.CQRS.RemoteHttp.Server/LeanCode.CQRS.RemoteHttp.Server.csproj
+++ b/src/Domain/LeanCode.CQRS.RemoteHttp.Server/LeanCode.CQRS.RemoteHttp.Server.csproj
@@ -5,6 +5,7 @@
     <ProjectReference Include="../LeanCode.CQRS.Execution/LeanCode.CQRS.Execution.csproj" />
     <ProjectReference Include="../LeanCode.CQRS.Security/LeanCode.CQRS.Security.csproj" />
     <ProjectReference Include="../../Core/LeanCode.Components/LeanCode.Components.csproj" />
+    <ProjectReference Include="../../Infrastructure/LeanCode.Serialization/LeanCode.Serialization.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Domain/LeanCode.CQRS.RemoteHttp.Server/RemoteCQRSMiddleware.cs
+++ b/src/Domain/LeanCode.CQRS.RemoteHttp.Server/RemoteCQRSMiddleware.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using LeanCode.Components;
+using LeanCode.Serialization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
@@ -120,7 +121,18 @@ namespace LeanCode.CQRS.RemoteHttp.Server
             TypesCatalog catalog,
             Func<HttpContext, TAppContext> contextTranslator)
         {
-            return builder.UseMiddleware<RemoteCQRSMiddleware<TAppContext>>(catalog, contextTranslator, new Utf8JsonSerializer());
+            return builder.UseMiddleware<RemoteCQRSMiddleware<TAppContext>>(
+                catalog,
+                contextTranslator,
+                new Utf8JsonSerializer(
+                    new JsonSerializerOptions
+                    {
+                        Converters =
+                        {
+                            new JsonDateOnlyConverter(),
+                            new JsonTimeOnlyConverter(),
+                        },
+                    }));
         }
 
         public static IApplicationBuilder UseRemoteCQRS<TAppContext>(

--- a/src/Infrastructure/LeanCode.Serialization/JsonConverters/JsonDateOnlyConverter.cs
+++ b/src/Infrastructure/LeanCode.Serialization/JsonConverters/JsonDateOnlyConverter.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LeanCode.Serialization;
+
+public class JsonDateOnlyConverter : JsonConverter<DateOnly>
+{
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetString() is string s
+            ? DateOnly.ParseExact(s, "o", CultureInfo.InvariantCulture)
+            : default;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString("o", CultureInfo.InvariantCulture));
+}

--- a/src/Infrastructure/LeanCode.Serialization/JsonConverters/JsonLaxDateOnlyConverter.cs
+++ b/src/Infrastructure/LeanCode.Serialization/JsonConverters/JsonLaxDateOnlyConverter.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LeanCode.Serialization;
+
+public class JsonLaxDateOnlyConverter : JsonConverter<DateOnly>
+{
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetString() is string s
+            ? DateOnly.FromDateTime(DateTime.Parse(s, CultureInfo.InvariantCulture))
+            : default;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString("o", CultureInfo.InvariantCulture));
+}

--- a/src/Infrastructure/LeanCode.Serialization/JsonConverters/JsonTimeOnlyConverter.cs
+++ b/src/Infrastructure/LeanCode.Serialization/JsonConverters/JsonTimeOnlyConverter.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LeanCode.Serialization;
+
+public class JsonTimeOnlyConverter : JsonConverter<TimeOnly>
+{
+    public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.GetString() is string s
+            ? TimeOnly.ParseExact(s, "o", CultureInfo.InvariantCulture)
+            : default;
+    }
+
+    public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString("o", CultureInfo.InvariantCulture));
+}

--- a/test/Infrastructure/LeanCode.Serialization.Tests/JsonConvertersTests.cs
+++ b/test/Infrastructure/LeanCode.Serialization.Tests/JsonConvertersTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using Xunit;
+
+namespace LeanCode.Serialization.Tests;
+
+public class JsonConvertersTests
+{
+    private static readonly JsonSerializerOptions DefaultSerializerOptions = new();
+
+    private static readonly JsonSerializerOptions LaxSerializerOptions = new();
+
+    static JsonConvertersTests()
+    {
+        DefaultSerializerOptions.Converters.Add(new JsonDateOnlyConverter());
+        DefaultSerializerOptions.Converters.Add(new JsonTimeOnlyConverter());
+
+        LaxSerializerOptions.Converters.Add(new JsonLaxDateOnlyConverter());
+    }
+
+    [Theory]
+    [InlineData("\"2021-12-15T00:00:00Z\"")]
+    public void Throws_when_attempting_to_deserialize_DateOnly_with_time_part(string serialized)
+    {
+        Assert.Throws<FormatException>(() => JsonSerializer.Deserialize<DateOnly>(serialized, DefaultSerializerOptions));
+    }
+
+    [Theory]
+    [InlineData("\"2021-12-15T00:00:00Z\"", 2021, 12, 15, "\"2021-12-15\"")]
+    public void Correctly_deserializes_DateOnly_with_time_part_when_using_lax_converter(
+        string serialized, int year, int month, int day, string reserialized)
+    {
+        var date = new DateOnly(year, month, day);
+
+        Assert.Equal(date, JsonSerializer.Deserialize<DateOnly>(serialized, LaxSerializerOptions));
+        Assert.Equal(reserialized, JsonSerializer.Serialize(date, LaxSerializerOptions));
+    }
+
+    [Theory]
+    [InlineData("\"2021-12-15\"", 2021, 12, 15)]
+    public void Correctly_serializes_and_deserializes_DateOnly(string serialized, int year, int month, int day)
+    {
+        var date = new DateOnly(year, month, day);
+
+        Assert.Equal(serialized, JsonSerializer.Serialize(date, DefaultSerializerOptions));
+        Assert.Equal(date, JsonSerializer.Deserialize<DateOnly>(serialized, DefaultSerializerOptions));
+    }
+
+    [Theory]
+    [InlineData("\"21:37:42.1230000\"", 21, 37, 42, 123)]
+    public void Correctly_serializes_and_deserializes_TimeOnly(string serialized, int hour, int minute, int second, int millisecond)
+    {
+        var time = new TimeOnly(hour, minute, second, millisecond);
+
+        Assert.Equal(serialized, JsonSerializer.Serialize(time, DefaultSerializerOptions));
+        Assert.Equal(time, JsonSerializer.Deserialize<TimeOnly>(serialized, DefaultSerializerOptions));
+    }
+}


### PR DESCRIPTION
Includes an optional `JsonLaxDateOnlyConverter` that also accepts and discards time parts.

Closes #318 (and projects running .NET 5.0 should implement their own `TimeSpan` converter).