### PR TITLE
Fix MT Serializer constructor handling

### DIFF
--- a/src/Domain/LeanCode.DomainModels.MassTransitRelay/Outbox/NewtonsoftJsonEventsSerializer.cs
+++ b/src/Domain/LeanCode.DomainModels.MassTransitRelay/Outbox/NewtonsoftJsonEventsSerializer.cs
@@ -23,6 +23,7 @@ namespace LeanCode.DomainModels.MassTransitRelay.Outbox
             this.typesCatalog = typesCatalog;
             this.settings = settings ?? new()
             {
+                ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
                 ContractResolver = new ContractResolver(),
             };
         }


### PR DESCRIPTION
Fixes issue that MT used incorrect (public constructor with default values instead of private parameterless consturctor) constructor when deserializing messages. 