### PR TITLE
Bump all dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,17 +1,17 @@
 <Project>
   <PropertyGroup>
-    <EntityFrameworkCoreVersion>6.0.3</EntityFrameworkCoreVersion>
-    <AspNetCoreVersion>6.0.3</AspNetCoreVersion>
+    <EntityFrameworkCoreVersion>6.0.10</EntityFrameworkCoreVersion>
+    <AspNetCoreVersion>6.0.10</AspNetCoreVersion>
     <ExtensionsVersion>6.0.0</ExtensionsVersion>
 
     <GoogleApisVersion>1.57.0</GoogleApisVersion>
-    <HangfireVersion>1.7.28</HangfireVersion>
+    <HangfireVersion>1.7.31</HangfireVersion>
     <IdentityServerVersion>4.1.2</IdentityServerVersion>
-    <SystemIdentityModelVersion>6.16.0</SystemIdentityModelVersion>
+    <SystemIdentityModelVersion>6.24.0</SystemIdentityModelVersion>
 
     <!-- Do not bump these dependencies if you don't want to force users to use newer .NET Core SDK -->
     <!-- Keep the major.minor values at exactly the one listed here: https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md -->
-    <CodeAnalysisVersion>4.0.1</CodeAnalysisVersion>
+    <CodeAnalysisVersion>4.2.0</CodeAnalysisVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,44 +24,44 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Autofac" Version="6.3.0" />
-    <PackageReference Update="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
+    <PackageReference Update="Autofac" Version="6.4.0" />
+    <PackageReference Update="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
 
-    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.1.1" />
-    <PackageReference Update="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.1" />
-    <PackageReference Update="Azure.Identity" Version="1.5.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.3.0" />
-    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
+    <PackageReference Update="Microsoft.Extensions.Azure" Version="1.6.0" />
+    <PackageReference Update="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
+    <PackageReference Update="Azure.Identity" Version="1.7.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.4.0" />
+    <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
 
-    <PackageReference Update="Serilog" Version="2.10.0" />
+    <PackageReference Update="Serilog" Version="2.12.0" />
     <PackageReference Update="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Update="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Update="Serilog.Settings.Configuration" Version="3.3.0" />
-    <PackageReference Update="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Update="Serilog.Sinks.Seq" Version="5.1.1" />
+    <PackageReference Update="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Update="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Update="Serilog.Sinks.Seq" Version="5.2.1" />
 
     <PackageReference Update="IdentityModel" Version="6.0.0" />
     <PackageReference Update="Microsoft.IdentityModel.Tokens" Version="$(SystemIdentityModelVersion)" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelVersion)" />
 
     <PackageReference Update="FirebaseAdmin" Version="2.3.0" />
-    <PackageReference Update="Google.Cloud.Firestore" Version="2.5.0" />
+    <PackageReference Update="Google.Cloud.Firestore" Version="3.0.0" />
 
-    <PackageReference Update="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageReference Update="Microsoft.Data.SqlClient" Version="5.0.1" />
 
     <PackageReference Update="Cronos" Version="0.7.1" />
     <PackageReference Update="Dapper" Version="2.0.123" />
     <PackageReference Update="FluentValidation" Version="9.5.4" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="Polly" Version="7.2.3" />
-    <PackageReference Update="Sendgrid" Version="9.27.0" />
+    <PackageReference Update="Sendgrid" Version="9.28.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
-    <PackageReference Update="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Update="Microsoft.AspNetCore.Razor.Language" Version="$(AspNetCoreVersion)" />
+    <PackageReference Update="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
 
     <PackageReference Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
@@ -76,7 +76,6 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Configuration.CommandLine" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Http" Version="$(ExtensionsVersion)" />
@@ -88,6 +87,8 @@
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
     <!-- Warning: this package seems to be versioned like one of AspNetCore packages :) -->
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="$(AspNetCoreVersion)" />
+    <!-- Warning: this package seems to be versioned completely separetely :) -->
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
 
     <!-- Warning: These are not versioned separately -->
     <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
@@ -108,18 +109,18 @@
     <PackageReference Update="IdentityServer4.EntityFramework.Storage" Version="$(IdentityServerVersion)" />
     <PackageReference Update="IdentityServer4.Storage" Version="$(IdentityServerVersion)" />
 
-    <PackageReference Update="MassTransit" Version="8.0.0" />
+    <PackageReference Update="MassTransit" Version="8.0.7" />
 
-    <PackageReference Update="OpenTelemetry" Version="1.2.0-rc3" />
+    <PackageReference Update="OpenTelemetry" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Update="NSubstitute" Version="4.3.0" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Update="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Update="NSubstitute" Version="4.4.0" />
+    <PackageReference Update="xunit" Version="2.4.2" />
+    <PackageReference Update="xunit.analyzers" Version="1.0.0" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Update="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 
@@ -132,6 +133,6 @@
     <AdditionalFiles Include="$(CodeAnalysisSettingsLocation)stylecop.json" />
 
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="'$(NoStyleCop)' != '1'" />
-    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.406" />
+    <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -59,9 +59,9 @@
 
   <ItemGroup>
     <PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetCoreVersion)" />
+    <PackageReference Update="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
     <PackageReference Update="Microsoft.AspNetCore.Razor.Language" Version="$(AspNetCoreVersion)" />
-    <PackageReference Update="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
 
     <PackageReference Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />

--- a/test/Infrastructure/LeanCode.ExternalIdentityProviders.Tests/Facebook/FacebookClientTests.cs
+++ b/test/Infrastructure/LeanCode.ExternalIdentityProviders.Tests/Facebook/FacebookClientTests.cs
@@ -33,10 +33,18 @@ namespace LeanCode.ExternalIdentityProviders.Tests.Facebook
             var user = await client.GetUserInfoAsync(AccessToken);
 
             Assert.NotNull(user);
+
             Assert.NotEmpty(user.Id);
+
+            Assert.NotNull(user.Email);
             Assert.NotEmpty(user.Email);
+
+            Assert.NotNull(user.FirstName);
             Assert.NotEmpty(user.FirstName);
+
+            Assert.NotNull(user.LastName);
             Assert.NotEmpty(user.LastName);
+
             Assert.NotEmpty(user.Photo);
         }
 

--- a/test/LeanCode.IntegrationTests/docker/docker-compose.yml
+++ b/test/LeanCode.IntegrationTests/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ../../..:/app/code
       - ~/.nuget:/home/dotnet/.nuget
     environment:
-      - SqlServer__ConnectionStringBase=Server=db,1433;User Id=sa;Password=Passw12#
+      - SqlServer__ConnectionStringBase=Server=db,1433;User Id=sa;Password=Passw12#;Encrypt=false
       - WAIT_FOR_DEBUGGER=${WAIT_FOR_DEBUGGER:-}
     depends_on:
       - db
@@ -29,14 +29,9 @@ services:
 
   #### Infrastructure
   db:
-    image: microsoft/mssql-server-linux:latest
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Passw12#
-    volumes:
-      - database:/var/opt/mssql
     ports:
       - "1433:1433"
-
-volumes:
-  database:

--- a/test/LeanCode.Test.Helpers/LeanCode.Test.Helpers.csproj
+++ b/test/LeanCode.Test.Helpers/LeanCode.Test.Helpers.csproj
@@ -4,8 +4,4 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="xunit" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
A couple of questions:
1. Should I bump the required version of Roslyn (4.2 will work correctly with .400 SDK)?
2. Should I bump the `Microsoft.Data.SqlClient` to v5 or leave it at v4?