### PR TITLE
Remove last explicit reference to Newtonsoft.Json

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -52,7 +52,6 @@
     <PackageReference Update="Cronos" Version="0.7.1" />
     <PackageReference Update="Dapper" Version="2.0.123" />
     <PackageReference Update="FluentValidation" Version="9.5.4" />
-    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="Polly" Version="7.2.3" />
     <PackageReference Update="Sendgrid" Version="9.28.1" />
   </ItemGroup>

--- a/src/Infrastructure/LeanCode.SendGrid/LeanCode.SendGrid.csproj
+++ b/src/Infrastructure/LeanCode.SendGrid/LeanCode.SendGrid.csproj
@@ -2,11 +2,6 @@
 
   <ItemGroup>
     <PackageReference Include="Sendgrid" />
-    <!--
-        Sendgrid relies on Newtonsoft.Json but on a much older version. We can bump it to our one
-        as it should really be backwards compatible.
-    -->
-    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We still depend on Newtonsoft.Json transitively if we use SendGrid or Hangfire, as these libs require it, but we don't depend on it explicitly anywhere anymore.

Fixes #327