### PR TITLE
RFC: Ulid<T> and SUlid<T>

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -53,6 +53,7 @@
     <PackageReference Update="FluentValidation" Version="9.5.4" />
     <PackageReference Update="Polly" Version="7.2.3" />
     <PackageReference Update="Sendgrid" Version="9.28.1" />
+    <PackageReference Update="Ulid" Version="1.2.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Domain/LeanCode.DomainModels.EF/IdConverter.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/IdConverter.cs
@@ -1,4 +1,3 @@
-using System;
 using LeanCode.DomainModels.Model;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
@@ -52,6 +51,32 @@ namespace LeanCode.DomainModels.EF
             : base(
                 d => d.Value,
                 d => SId<T>.From(d),
+                mappingHints: null)
+        { }
+    }
+
+    public class UlidConverter<T> : ValueConverter<Ulid<T>, string>
+        where T : class, IIdentifiable<Ulid<T>>
+    {
+        public static readonly UlidConverter<T> Instance = new();
+
+        public UlidConverter()
+            : base(
+                model => model.ToString(),
+                provider => Ulid<T>.Parse(provider),
+                mappingHints: null)
+        { }
+    }
+
+    public class SUlidConverter<T> : ValueConverter<SUlid<T>, string>
+        where T : class, IIdentifiable<SUlid<T>>
+    {
+        public static readonly SUlidConverter<T> Instance = new();
+
+        public SUlidConverter()
+            : base(
+                model => model.Value,
+                provider => SUlid<T>.FromString(provider),
                 mappingHints: null)
         { }
     }

--- a/src/Domain/LeanCode.DomainModels.EF/PropertiesConfigurationBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/PropertiesConfigurationBuilderExtensions.cs
@@ -1,0 +1,44 @@
+using LeanCode.DomainModels.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LeanCode.DomainModels.EF;
+
+public static class PropertiesConfigurationBuilderExtensions
+{
+    public static PropertiesConfigurationBuilder<SUlid<T>> AreTypedId<T>(this PropertiesConfigurationBuilder<SUlid<T>> builder)
+        where T : class, IIdentifiable<SUlid<T>>
+    {
+        return builder
+            .HaveConversion<SUlidConverter<T>>()
+            .HaveMaxLength(SUlid<T>.RawLength)
+            .AreFixedLength();
+    }
+
+    public static PropertiesConfigurationBuilder<SUlid<T>?> AreTypedId<T>(this PropertiesConfigurationBuilder<SUlid<T>?> builder)
+        where T : class, IIdentifiable<SUlid<T>>
+    {
+        return builder
+            .HaveConversion<SUlidConverter<T>>()
+            .HaveMaxLength(SUlid<T>.RawLength)
+            .AreFixedLength();
+    }
+
+    public static PropertiesConfigurationBuilder<Ulid<T>> AreTypedId<T>(this PropertiesConfigurationBuilder<Ulid<T>> builder)
+        where T : class, IIdentifiable<Ulid<T>>
+    {
+        return builder
+            .HaveConversion<UlidConverter<T>>()
+            .HaveMaxLength(26)
+            .AreFixedLength();
+    }
+
+    public static PropertiesConfigurationBuilder<Ulid<T>?> AreTypedId<T>(this PropertiesConfigurationBuilder<Ulid<T>?> builder)
+        where T : class, IIdentifiable<Ulid<T>>
+    {
+        return builder
+            .HaveConversion<UlidConverter<T>>()
+            .HaveMaxLength(26)
+            .AreFixedLength();
+    }
+}

--- a/src/Domain/LeanCode.DomainModels/LeanCode.DomainModels.csproj
+++ b/src/Domain/LeanCode.DomainModels/LeanCode.DomainModels.csproj
@@ -1,3 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <ItemGroup>
+    <PackageReference Include="Ulid" />
+  </ItemGroup>
+
 </Project>

--- a/src/Domain/LeanCode.DomainModels/Model/IdSlugAttribute.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/IdSlugAttribute.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+
+namespace LeanCode.DomainModels.Model;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+public sealed class IdSlugAttribute : Attribute
+{
+    public string Slug { get; }
+
+    public IdSlugAttribute(string slug)
+    {
+        Slug = slug;
+    }
+
+    public static string? GetSlug<T>() => GetSlug(typeof(T));
+
+    public static string? GetSlug(Type t) => t.GetCustomAttribute<IdSlugAttribute>()?.Slug;
+}
+
+internal static class SIdExtensions
+{
+    internal static string GetPrefix<TEntity>()
+    {
+        const int MaxTypeLength = 10;
+
+        if (IdSlugAttribute.GetSlug<TEntity>() is string v)
+        {
+            return v;
+        }
+        else
+        {
+            var typename = typeof(TEntity).Name.ToLowerInvariant();
+
+            if (typename.Length > MaxTypeLength)
+            {
+                return typename[0..MaxTypeLength];
+            }
+            else
+            {
+                return typename;
+            }
+        }
+    }
+}

--- a/src/Domain/LeanCode.DomainModels/Model/SId.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/SId.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using LeanCode.DomainModels.Serialization;
 
 namespace LeanCode.DomainModels.Model
@@ -14,8 +13,7 @@ namespace LeanCode.DomainModels.Model
     {
         private const int GuidLength = 32;
         private const char Separator = '_';
-        private const int MaxTypeLength = 10;
-        private static readonly string TypeName = ExtractType();
+        private static readonly string TypeName = SIdExtensions.GetPrefix<TEntity>();
 
         public static readonly int RawLength = GuidLength + 1 + TypeName.Length;
         public static readonly SId<TEntity> Empty = new(Guid.Empty);
@@ -128,40 +126,5 @@ namespace LeanCode.DomainModels.Model
 
         public override string ToString() => Value;
         public static implicit operator string(SId<TEntity> id) => id.Value;
-
-        private static string ExtractType()
-        {
-            if (IdSlugAttribute.GetSlug<TEntity>() is string v)
-            {
-                return v;
-            }
-            else
-            {
-                var typename = typeof(TEntity).Name.ToLowerInvariant();
-                if (typename.Length > MaxTypeLength)
-                {
-                    return typename[0..MaxTypeLength];
-                }
-                else
-                {
-                    return typename;
-                }
-            }
-        }
-    }
-
-    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-    public sealed class IdSlugAttribute : Attribute
-    {
-        public string Slug { get; }
-
-        public IdSlugAttribute(string slug)
-        {
-            Slug = slug;
-        }
-
-        public static string? GetSlug<T>() => GetSlug(typeof(T));
-        public static string? GetSlug(Type t) =>
-            t.GetCustomAttribute<IdSlugAttribute>()?.Slug;
     }
 }

--- a/src/Domain/LeanCode.DomainModels/Model/SUlid.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/SUlid.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace LeanCode.DomainModels.Model;
+
+/// <summary>A stronly typed id consisting of an ulid prefixed with a lower-cased name of an entity.</summary>
+/// <remarks>Use <see cref="IdSlugAttribute"/> to override default entity prefix.</remarks>
+[Serialization.TypedIdConverter]
+[System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
+[SuppressMessage("?", "CA1000", Justification = "The methods are expected.")]
+[SuppressMessage("?", "CA1036", Justification = "We don't want to have easy comparison as it might be abused.")]
+public readonly record struct SUlid<TEntity> : IEquatable<SUlid<TEntity>>, IComparable<SUlid<TEntity>>
+    where TEntity : class, IIdentifiable<SUlid<TEntity>>
+{
+    private const int UlidLength = 26;
+    private const char Separator = '_';
+    private static readonly string TypeName = SIdExtensions.GetPrefix<TEntity>();
+
+    public static readonly int RawLength = UlidLength + 1 + TypeName.Length;
+    public static readonly SUlid<TEntity> Empty = new(Ulid.Empty);
+
+    private readonly string? value;
+
+    public string Value => value ?? Empty.Value;
+
+    private SUlid(string str)
+    {
+        value = str;
+    }
+
+    public SUlid(Ulid ulid)
+    {
+        value = string.Create(
+            RawLength,
+            ulid,
+            static (span, ulid) =>
+            {
+                TypeName.CopyTo(span);
+                span[TypeName.Length] = Separator;
+                ulid.TryWriteStringify(span[(TypeName.Length + 1)..]);
+            });
+    }
+
+    public static SUlid<TEntity> New() => new(Ulid.NewUlid());
+
+    [return: NotNullIfNotNull("id")]
+    public static SUlid<TEntity>? FromNullableString(string? id) => id is string v ? FromString(v) : null;
+
+    public static bool TryParse(string? v, out SUlid<TEntity> id)
+    {
+        if (IsValid(v))
+        {
+            id = new SUlid<TEntity>(v);
+            return true;
+        }
+        else
+        {
+            id = default;
+            return false;
+        }
+    }
+
+    public static SUlid<TEntity> FromString(string v)
+    {
+        if (IsValid(v))
+        {
+            return new SUlid<TEntity>(v);
+        }
+        else
+        {
+            throw new FormatException($"The id has invalid format. It should look like {TypeName}{Separator}(random id).");
+        }
+    }
+
+    public static SUlid<TEntity> FromUlidOrSUlid(string v)
+    {
+        if (TryParse(v, out var sulid))
+        {
+            return sulid;
+        }
+        else if (Ulid.TryParse(v, out var ulid))
+        {
+            return new(ulid);
+        }
+        else
+        {
+            throw new FormatException($"The id cannot be parsed to SUlid nor Ulid.");
+        }
+    }
+
+    public static bool TryParseFromUlidOrSUlid([NotNullWhen(true)] string? v, out SUlid<TEntity> id)
+    {
+        if (IsValid(v))
+        {
+            id = new SUlid<TEntity>(v!);
+            return true;
+        }
+        else if (Ulid.TryParse(v, out var ulid))
+        {
+            id = new(ulid);
+            return true;
+        }
+        else
+        {
+            id = default;
+            return false;
+        }
+    }
+
+    public static bool IsValid([NotNullWhen(true)] string? v)
+    {
+        if (v is null)
+        {
+            return false;
+        }
+        else
+        {
+            var span = v.AsSpan();
+            return
+                span.Length == RawLength &&
+                span.StartsWith(TypeName) &&
+                span[TypeName.Length] == Separator &&
+                Ulid.TryParse(span[(TypeName.Length + 1)..], out _);
+        }
+    }
+
+    public bool Equals(SUlid<TEntity> other) => Value.Equals(other.Value, StringComparison.Ordinal);
+
+    public int CompareTo(SUlid<TEntity> other) => string.Compare(Value, other.Value, StringComparison.Ordinal);
+
+    public override int GetHashCode() => Value.GetHashCode(StringComparison.Ordinal);
+
+    public override string ToString() => Value;
+
+    public static implicit operator string(SUlid<TEntity> id) => id.Value;
+}

--- a/src/Domain/LeanCode.DomainModels/Model/Ulid.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/Ulid.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace LeanCode.DomainModels.Model;
+
+[Serialization.TypedIdConverter]
+[System.Diagnostics.DebuggerDisplay("{Value,nq}")]
+[SuppressMessage("?", "CA1000", Justification = "The methods are expected.")]
+[SuppressMessage("?", "CA1036", Justification = "We don't want to have easy comparison as it might be abused.")]
+public readonly record struct Ulid<TEntity>(Ulid Value) : IComparable<Ulid<TEntity>>
+    where TEntity : class, IIdentifiable<Ulid<TEntity>>
+{
+    public static readonly Ulid<TEntity> Empty;
+
+    public static Ulid<TEntity> FromUlid(Ulid id) => new(id);
+    public static Ulid<TEntity>? FromUlid(Ulid? id) => id is Ulid v ? new Ulid<TEntity>(v) : null;
+
+    public static Ulid<TEntity> New() => new(Ulid.NewUlid());
+
+    public static Ulid<TEntity> Parse(ReadOnlySpan<char> base32) => new(Ulid.Parse(base32));
+
+    public static Ulid<TEntity> Parse(string base32) => new(Ulid.Parse(base32));
+
+    public static bool TryParse(ReadOnlySpan<char> base32, out Ulid<TEntity>? ulid) =>
+        (Ulid.TryParse(base32, out var u) ? ulid = new(u) : ulid = default) is not null;
+
+    public static bool TryParse([NotNullWhen(true)] string? base32, out Ulid<TEntity>? ulid) =>
+        (Ulid.TryParse(base32, out var u) ? ulid = new(u) : ulid = default) is not null;
+
+    public int CompareTo(Ulid<TEntity> other) => Value.CompareTo(other.Value);
+
+    public override string ToString() => Value.ToString();
+
+    public Ulid ToUlid() => Value;
+
+    public static implicit operator Ulid(Ulid<TEntity> id) => id.Value;
+
+    public static explicit operator Ulid<TEntity>(Ulid id) => new(id);
+}


### PR DESCRIPTION
That's pretty much how I imagine this to work. I'm not yet sure about the public API surface for `SUlid<T>` though (and it's _not_ consistent with `SId<T>` precisely so we can discuss a new iteration) so feel free to suggest changes.

Notable changes from existing types:

1. New structs are `record` types so I don't have to write some of equality boilerplate, at least for `Ulid<T>`.
2. EF converters have public constructors so they can be used in `HaveConversion` methods.
3. EF extensions are for DB-wide conventions instead of per-column configuration.

We could also consider allowing passing custom collation / column type because we don't really need anything more than a ordinal comparison but we can't set any reasonable defaults anyway. At best we could do something like `.UseSqlServerUtf8Column(string? collation)` which could expand to `.HaveColumnType("nchar(26)").UseCollation(collation ?? "Latin1_General_100_BIN2_UTF8").AreUnicode()` but that's gross.

I'll add some tests once we're sure we want this.