### PR TITLE
Accept custom suffixes for the main branches in GH actions builds.

### DIFF
--- a/.github/workflows/core_build_publish.yml
+++ b/.github/workflows/core_build_publish.yml
@@ -3,7 +3,7 @@ name: Corelibrary Build & Publish
 on:
   push:
     branches:
-      - "v[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+-?*"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
This is to support `v8.0-vNext` branch. It will be built, but not published - the publish check depends on `^v[0-9]+.[0-9]+$` regex