### PR TITLE
Pass HttpContext to IValidationContext in LeanCode.CQRS.Validation.Fl…

### DIFF
--- a/src/Domain/LeanCode.CQRS.Validation.Fluent.Scoped/ValidationContextExtensions.cs
+++ b/src/Domain/LeanCode.CQRS.Validation.Fluent.Scoped/ValidationContextExtensions.cs
@@ -17,7 +17,7 @@ public static class ValidationContextExtensions
         else
         {
             throw new InvalidOperationException(
-                "`HttpContext` is not available in validation context. Ensure you are calling the validator through FluentValidationCommandValidatorAdapter"
+                "`HttpContext` is not available in validation context. Ensure you are calling the validator through FluentValidationCommandValidatorAdapter."
             );
         }
     }

--- a/src/Domain/LeanCode.CQRS.Validation.Fluent.Scoped/ValidationContextExtensions.cs
+++ b/src/Domain/LeanCode.CQRS.Validation.Fluent.Scoped/ValidationContextExtensions.cs
@@ -2,7 +2,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace LeanCode.CQRS.Validation.Fluent;
+namespace LeanCode.CQRS.Validation.Fluent.Scoped;
 
 public static class ValidationContextExtensions
 {
@@ -17,7 +17,7 @@ public static class ValidationContextExtensions
         else
         {
             throw new InvalidOperationException(
-                "Cannot use `HttpContext` extension method outside the `ContextualValidator` class."
+                "`HttpContext` is not available in validation context. Ensure you are calling the validator through FluentValidationCommandValidatorAdapter"
             );
         }
     }
@@ -25,15 +25,6 @@ public static class ValidationContextExtensions
     public static T GetService<T>(this IValidationContext ctx)
         where T : notnull
     {
-        if (ctx.RootContextData.TryGetValue(HttpContextKey, out var httpContext))
-        {
-            return ((HttpContext)httpContext).RequestServices.GetRequiredService<T>();
-        }
-        else
-        {
-            throw new InvalidOperationException(
-                "Cannot use `GetService` extension method outside the `ContextualValidator` class."
-            );
-        }
+        return ctx.HttpContext().RequestServices.GetRequiredService<T>();
     }
 }

--- a/src/Domain/LeanCode.CQRS.Validation.Fluent/FluentValidationCommandValidatorAdapter.cs
+++ b/src/Domain/LeanCode.CQRS.Validation.Fluent/FluentValidationCommandValidatorAdapter.cs
@@ -21,7 +21,7 @@ public class FluentValidationCommandValidatorAdapter<TCommand> : ICommandValidat
     {
         var ctx = PrepareContext(httpContext, command);
 
-        var fluentValidationResult = await fluentValidator.ValidateAsync(ctx);
+        var fluentValidationResult = await fluentValidator.ValidateAsync(ctx, httpContext.RequestAborted);
 
         var mappedResult = fluentValidationResult.Errors.Select(MapFluentError).ToList();
 


### PR DESCRIPTION
…uent.Scoped.

Since with `IServiceProvider` we can't inject it via parameter hints, restoring the `RootContextData` injection. One can still use an `IHttpContextAccessor`, but I still think it's easier that way.