### PR TITLE
Use plain Task.Delay when waiting for MT outbox in tests

### DIFF
--- a/src/CQRS/LeanCode.CQRS.MassTransitRelay/MassTransitRelayServiceCollectionExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.MassTransitRelay/MassTransitRelayServiceCollectionExtensions.cs
@@ -35,7 +35,11 @@ public static class MassTransitRelayServiceCollectionExtensions
         return services;
     }
 
-    public static void AddBusActivityMonitor(this IServiceCollection services, TimeSpan? inactivityWaitTime = null)
+    public static void AddBusActivityMonitor(
+        this IServiceCollection services,
+        TimeSpan? inactivityWaitTime = null,
+        bool initializeAtStartup = true
+    )
     {
         services.AddSingleton(
             sp =>
@@ -45,5 +49,10 @@ public static class MassTransitRelayServiceCollectionExtensions
                 )
         );
         services.AddSingleton<IBusActivityMonitor>(sp => sp.GetRequiredService<ResettableBusActivityMonitor>());
+
+        if (initializeAtStartup)
+        {
+            services.AddHostedService<ResettableBusActivityMonitorInitializer>();
+        }
     }
 }

--- a/src/CQRS/LeanCode.CQRS.MassTransitRelay/Testing/ResettableBusActivityMonitorInitializer.cs
+++ b/src/CQRS/LeanCode.CQRS.MassTransitRelay/Testing/ResettableBusActivityMonitorInitializer.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Hosting;
+
+namespace LeanCode.CQRS.MassTransitRelay.Testing;
+
+internal class ResettableBusActivityMonitorInitializer : IHostedService
+{
+    public ResettableBusActivityMonitorInitializer(ResettableBusActivityMonitor monitor)
+    {
+        // ServiceCollection does not allow any auto-initialize of services,
+        // so we just want to instantiate it somehow, to start observing the bus
+        _ = monitor;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/test/LeanCode.IntegrationTests/App/Startup.cs
+++ b/test/LeanCode.IntegrationTests/App/Startup.cs
@@ -39,8 +39,6 @@ public class Startup : LeanStartup
             busCfg.AddConsumer<EntityAddedConsumer, EntityAddedConsumerDefinition>();
             busCfg.AddEntityFrameworkOutbox<TestDbContext>(outboxCfg =>
             {
-                outboxCfg.QueryDelay = TimeSpan.FromSeconds(0.5);
-
                 outboxCfg.UseSqlServer();
                 outboxCfg.UseBusOutbox();
             });

--- a/test/LeanCode.IntegrationTests/TestApp.cs
+++ b/test/LeanCode.IntegrationTests/TestApp.cs
@@ -1,17 +1,10 @@
 using System.Diagnostics;
 using System.Reflection;
-using FluentAssertions;
-using LeanCode.CQRS.MassTransitRelay;
 using LeanCode.IntegrationTestHelpers;
 using LeanCode.IntegrationTests.App;
 using LeanCode.Logging;
 using LeanCode.Startup.MicrosoftDI;
-using MassTransit.Middleware.Outbox;
-using MassTransit.Testing.Implementations;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Serilog.Events;
 
 namespace LeanCode.IntegrationTests;
 


### PR DESCRIPTION
Two problems with `IBusOutboxNotification`:
1. It's not thread safe
2. Actually I misunderstood it's purpose - it's used by outbox to wait for messages to send so it marks the start of outbox publication and not the end :see_no_evil:   

So, we resort to good'ol sleepin'. 