### PR TITLE
Use UTC timestamps where appropriate

### DIFF
--- a/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
@@ -23,7 +23,7 @@ public abstract class EFRepository<TEntity, TIdentity, TContext> : IRepository<T
     {
         if (entity is IOptimisticConcurrency oc)
         {
-            oc.DateModified = Time.Now;
+            oc.DateModified = Time.UtcNow;
         }
 
         DbSet.Add(entity);
@@ -33,7 +33,7 @@ public abstract class EFRepository<TEntity, TIdentity, TContext> : IRepository<T
     {
         if (entity is IOptimisticConcurrency oc)
         {
-            oc.DateModified = Time.Now;
+            oc.DateModified = Time.UtcNow;
         }
 
         DbSet.Remove(entity);
@@ -43,7 +43,7 @@ public abstract class EFRepository<TEntity, TIdentity, TContext> : IRepository<T
     {
         foreach (var oc in entities.OfType<IOptimisticConcurrency>())
         {
-            oc.DateModified = Time.Now;
+            oc.DateModified = Time.UtcNow;
         }
 
         DbSet.RemoveRange(entities);
@@ -53,7 +53,7 @@ public abstract class EFRepository<TEntity, TIdentity, TContext> : IRepository<T
     {
         if (entity is IOptimisticConcurrency oc)
         {
-            oc.DateModified = Time.Now;
+            oc.DateModified = Time.UtcNow;
         }
     }
 

--- a/src/Domain/LeanCode.TimeProvider/Time.cs
+++ b/src/Domain/LeanCode.TimeProvider/Time.cs
@@ -4,6 +4,7 @@ public static class Time
 {
     public static System.TimeProvider Provider { get; set; } = UtcSystemTimeProvider.Instance;
 
+    public static DateTime UtcNow => NowWithOffset.UtcDateTime;
     public static DateTime Now => NowWithOffset.DateTime;
     public static DateTimeOffset NowWithOffset => Provider.GetLocalNow();
 }

--- a/src/Infrastructure/LeanCode.Firebase.FCM.PostgreSql/PgSqlPushNotificationTokenStore.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM.PostgreSql/PgSqlPushNotificationTokenStore.cs
@@ -77,7 +77,7 @@ public sealed class PgSqlPushNotificationTokenStore<TDbContext> : IPushNotificat
                     newId = Guid.NewGuid(),
                     userId,
                     newToken,
-                    now = Time.Now
+                    now = Time.UtcNow
                 },
                 cancellationToken: cancellationToken
             );

--- a/src/Infrastructure/LeanCode.Firebase.FCM.SqlServer/MsSqlPushNotificationTokenStore.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM.SqlServer/MsSqlPushNotificationTokenStore.cs
@@ -80,7 +80,7 @@ public sealed class MsSqlPushNotificationTokenStore<TDbContext> : IPushNotificat
                     newId = Guid.NewGuid(),
                     userId,
                     newToken,
-                    now = Time.Now
+                    now = Time.UtcNow
                 },
                 cancellationToken: cancellationToken
             );

--- a/src/Infrastructure/LeanCode.PeriodicService/PeriodicHostedService.cs
+++ b/src/Infrastructure/LeanCode.PeriodicService/PeriodicHostedService.cs
@@ -55,7 +55,7 @@ public class PeriodicHostedService<TAction> : BackgroundService
 
     private static TimeSpan CalculateDelay(IPeriodicAction action)
     {
-        var now = TimeProvider.Time.Now;
+        var now = TimeProvider.Time.UtcNow;
         var next =
             action.When.GetNextOccurrence(now, false)
             ?? throw new InvalidOperationException("Cannot get next occurrence of the task.");

--- a/test/CQRS/LeanCode.CQRS.MassTransitRelay.Tests/Integration/TestEvents.cs
+++ b/test/CQRS/LeanCode.CQRS.MassTransitRelay.Tests/Integration/TestEvents.cs
@@ -13,7 +13,7 @@ public class Event1 : IDomainEvent
     {
         CorrelationId = correlationId;
         Id = Guid.NewGuid();
-        DateOccurred = Time.Now;
+        DateOccurred = Time.UtcNow;
     }
 }
 
@@ -26,7 +26,7 @@ public class Event2 : IDomainEvent
     public Event2(Guid correlationId)
     {
         Id = Guid.NewGuid();
-        DateOccurred = Time.Now;
+        DateOccurred = Time.UtcNow;
         CorrelationId = correlationId;
     }
 }
@@ -40,7 +40,7 @@ public class Event3 : IDomainEvent
     public Event3(Guid correlationId)
     {
         Id = Guid.NewGuid();
-        DateOccurred = Time.Now;
+        DateOccurred = Time.UtcNow;
         CorrelationId = correlationId;
     }
 }

--- a/test/Domain/LeanCode.TimeProvider.Tests/TimeProviderTests.cs
+++ b/test/Domain/LeanCode.TimeProvider.Tests/TimeProviderTests.cs
@@ -57,6 +57,16 @@ public abstract class TimeProviderTests
         Assert.Equal(expectedTime.DateTime, now);
         Assert.Equal(DateTimeKind.Unspecified, now.Kind);
     }
+
+    [Fact]
+    public void TimeUtcNow_returns_timestamp_in_UTC_time_zone()
+    {
+        TestTimeProvider.ActivateFake(expectedTime, timeZoneInfo);
+
+        var utcNow = Time.UtcNow;
+        Assert.Equal(expectedTime.UtcDateTime, utcNow);
+        Assert.Equal(DateTimeKind.Utc, utcNow.Kind);
+    }
 }
 
 public class TimeProviderTests1 : TimeProviderTests

--- a/test/LeanCode.IntegrationTests/App/Entity.cs
+++ b/test/LeanCode.IntegrationTests/App/Entity.cs
@@ -30,7 +30,7 @@ public class EntityAdded : IDomainEvent
     public EntityAdded(Entity entity)
     {
         Id = Guid.NewGuid();
-        DateOccurred = Time.Now;
+        DateOccurred = Time.UtcNow;
 
         EntityId = entity.Id;
         Value = entity.Value;


### PR DESCRIPTION
While this is a bit more than we discussed, there could be similar issues whenever we want to persist any `DateTime` in PostgreSQL (and MSSQL change is just for consistency, we can drop that one). If you believe that we shouldn't do some of the changes proposed here, let me know, preferably with an explanation (and I'll try to explain why not doing them could be problematic).

Also, maybe we should introduce `UtcNow` property in `Time` that is guaranteed to return UTC timestamps?