### PR TITLE
Introduce TimestampTz value object for use with PostgreSQL

### DIFF
--- a/src/Domain/LeanCode.DomainModels.EF/QueryExpressionVisitorInterceptor.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/QueryExpressionVisitorInterceptor.cs
@@ -1,0 +1,10 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace LeanCode.DomainModels.EF;
+
+public sealed class QueryExpressionVisitorInterceptor(ExpressionVisitor visitor) : IQueryExpressionInterceptor
+{
+    public Expression QueryCompilationStarting(Expression queryExpression, QueryExpressionEventData eventData) =>
+        visitor.Visit(queryExpression);
+}

--- a/src/Domain/LeanCode.DomainModels.EF/TimestampTzExpressionInterceptor.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/TimestampTzExpressionInterceptor.cs
@@ -11,23 +11,23 @@ public sealed class TimestampTzExpressionRewriter : ExpressionVisitor
     private static readonly Type TimeZoneInfoType = typeof(TimeZoneInfo);
     private static readonly Type DateTimeOffsetType = typeof(DateTimeOffset);
 
-    private static readonly PropertyInfo LocalTimestampWithoutOffsetProperty =
+    public static readonly PropertyInfo LocalTimestampWithoutOffsetProperty =
         TimestampTzType.GetProperty(nameof(TimestampTz.LocalTimestampWithoutOffset))
         ?? throw new MissingMemberException(TimestampTzType.FullName, nameof(TimestampTz.LocalTimestampWithoutOffset));
 
-    private static readonly PropertyInfo UtcTimestampProperty =
+    public static readonly PropertyInfo UtcTimestampProperty =
         TimestampTzType.GetProperty(nameof(TimestampTz.UtcTimestamp))
         ?? throw new MissingMemberException(TimestampTzType.FullName, nameof(TimestampTz.UtcTimestamp));
 
-    private static readonly PropertyInfo TimeZoneIdProperty =
+    public static readonly PropertyInfo TimeZoneIdProperty =
         TimestampTzType.GetProperty(nameof(TimestampTz.TimeZoneId))
         ?? throw new MissingMemberException(TimestampTzType.FullName, nameof(TimestampTz.TimeZoneId));
 
-    private static readonly PropertyInfo UtcDateTimeProperty =
+    public static readonly PropertyInfo UtcDateTimeProperty =
         DateTimeOffsetType.GetProperty(nameof(DateTimeOffset.UtcDateTime))
         ?? throw new MissingMemberException(DateTimeOffsetType.FullName, nameof(DateTimeOffset.UtcDateTime));
 
-    private static readonly MethodInfo ConvertDateTimeBySystemTimeZoneIdMethod =
+    public static readonly MethodInfo ConvertDateTimeBySystemTimeZoneIdMethod =
         TimeZoneInfoType.GetMethod(
             nameof(TimeZoneInfo.ConvertTimeBySystemTimeZoneId),
             new[] { typeof(DateTime), typeof(string) }

--- a/src/Domain/LeanCode.DomainModels.EF/TimestampTzExpressionInterceptor.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/TimestampTzExpressionInterceptor.cs
@@ -1,0 +1,69 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using LeanCode.DomainModels.Model;
+using Microsoft.EntityFrameworkCore;
+
+namespace LeanCode.DomainModels.EF;
+
+public sealed class TimestampTzExpressionRewriter : ExpressionVisitor
+{
+    private static readonly Type TimestampTzType = typeof(TimestampTz);
+    private static readonly Type TimeZoneInfoType = typeof(TimeZoneInfo);
+    private static readonly Type DateTimeOffsetType = typeof(DateTimeOffset);
+
+    private static readonly PropertyInfo LocalTimestampWithoutOffsetProperty =
+        TimestampTzType.GetProperty(nameof(TimestampTz.LocalTimestampWithoutOffset))
+        ?? throw new MissingMemberException(TimestampTzType.FullName, nameof(TimestampTz.LocalTimestampWithoutOffset));
+
+    private static readonly PropertyInfo UtcTimestampProperty =
+        TimestampTzType.GetProperty(nameof(TimestampTz.UtcTimestamp))
+        ?? throw new MissingMemberException(TimestampTzType.FullName, nameof(TimestampTz.UtcTimestamp));
+
+    private static readonly PropertyInfo TimeZoneIdProperty =
+        TimestampTzType.GetProperty(nameof(TimestampTz.TimeZoneId))
+        ?? throw new MissingMemberException(TimestampTzType.FullName, nameof(TimestampTz.TimeZoneId));
+
+    private static readonly PropertyInfo UtcDateTimeProperty =
+        DateTimeOffsetType.GetProperty(nameof(DateTimeOffset.UtcDateTime))
+        ?? throw new MissingMemberException(DateTimeOffsetType.FullName, nameof(DateTimeOffset.UtcDateTime));
+
+    private static readonly MethodInfo ConvertDateTimeBySystemTimeZoneIdMethod =
+        TimeZoneInfoType.GetMethod(
+            nameof(TimeZoneInfo.ConvertTimeBySystemTimeZoneId),
+            new[] { typeof(DateTime), typeof(string) }
+        )
+        ?? throw new MissingMemberException(
+            TimeZoneInfoType.FullName,
+            nameof(TimeZoneInfo.ConvertTimeBySystemTimeZoneId)
+        );
+
+    protected override Expression VisitMember(MemberExpression node)
+    {
+        if (node.Member == LocalTimestampWithoutOffsetProperty)
+        {
+            return Expression.Call(
+                null,
+                ConvertDateTimeBySystemTimeZoneIdMethod,
+                Expression.Property(Expression.Property(node.Expression, UtcTimestampProperty), UtcDateTimeProperty),
+                Expression.Property(node.Expression, TimeZoneIdProperty)
+            );
+        }
+        else
+        {
+            return node;
+        }
+    }
+}
+
+public static class TimestampTzExpressionInterceptorDbContextOptionsBuilderExtensions
+{
+    public static readonly QueryExpressionVisitorInterceptor Interceptor = new(new TimestampTzExpressionRewriter());
+
+    public static DbContextOptionsBuilder AddTimestampTzExpressionInterceptor(
+        this DbContextOptionsBuilder optionsBuilder
+    )
+    {
+        optionsBuilder.AddInterceptors(Interceptor);
+        return optionsBuilder;
+    }
+}

--- a/src/Domain/LeanCode.DomainModels/Model/TimestampTz.cs
+++ b/src/Domain/LeanCode.DomainModels/Model/TimestampTz.cs
@@ -1,0 +1,93 @@
+using System.Text.Json.Serialization;
+
+namespace LeanCode.DomainModels.Model;
+
+/// <remarks>
+/// This type is intended to be used with PostgreSQL which supports AT TIME ZONE operator
+/// with IANA time zone IDs but cannot store both timestamp and offset in a single column.
+/// </remarks>
+public sealed record class TimestampTz : ValueObject
+{
+    [JsonIgnore]
+    public TimeZoneInfo TimeZoneInfo => TimeZoneInfo.FindSystemTimeZoneById(TimeZoneId);
+
+    /// <summary>
+    /// Returns contained timestamp in local time as DateTime.
+    /// Can be evaluated database-side with PostgreSQL but the offset is lost during conversion.
+    /// </summary>
+    [JsonIgnore]
+    public DateTime LocalTimestampWithoutOffset =>
+        TimeZoneInfo.ConvertTimeBySystemTimeZoneId(UtcTimestamp, TimeZoneId).DateTime;
+
+    /// <summary>
+    /// Returns contained timestamp in local time as DateTimeOffset.
+    /// Cannot be evaluated database-side with PostgreSQL.
+    /// </summary>
+    [JsonIgnore]
+    public DateTimeOffset LocalTimestampWithOffset =>
+        TimeZoneInfo.ConvertTimeBySystemTimeZoneId(UtcTimestamp, TimeZoneId);
+
+    /// <summary>
+    /// Always stored with offset equal to zero.
+    /// </summary>
+    [JsonInclude]
+    public DateTimeOffset UtcTimestamp { get; private init; }
+
+    /// <summary>
+    /// Always expressed using IANA identifier.
+    /// </summary>
+    [JsonInclude]
+    public string TimeZoneId { get; private init; }
+
+    public static bool IsValidTimeZoneId(string timeZoneId)
+    {
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneId, out var ianaId))
+        {
+            timeZoneId = ianaId;
+        }
+
+        return TimeZoneInfo.TryFindSystemTimeZoneById(timeZoneId, out var timeZoneInfo) && timeZoneInfo.HasIanaId;
+    }
+
+    [JsonConstructor]
+    private TimestampTz()
+    {
+        TimeZoneId = default!;
+    }
+
+    public TimestampTz(DateTimeOffset timestamp, TimeZoneInfo timeZoneInfo)
+        : this(timestamp.UtcDateTime, timeZoneInfo.Id) { }
+
+    public TimestampTz(DateTimeOffset timestamp, string timeZoneId)
+        : this(timestamp.UtcDateTime, timeZoneId) { }
+
+    public TimestampTz(DateTime utcTimestamp, TimeZoneInfo timeZoneInfo)
+        : this(utcTimestamp, timeZoneInfo.Id) { }
+
+    public TimestampTz(DateTime utcTimestamp, string timeZoneId)
+    {
+        if (utcTimestamp.Kind != DateTimeKind.Utc)
+        {
+            throw new ArgumentException("Timestamp's Kind must be Utc.", nameof(utcTimestamp));
+        }
+
+        if (TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneId, out var ianaId))
+        {
+            timeZoneId = ianaId;
+        }
+
+        if (!TimeZoneInfo.FindSystemTimeZoneById(timeZoneId).HasIanaId)
+        {
+            throw new ArgumentException("TimeZoneId must have associated IANA identifier.", nameof(timeZoneId));
+        }
+
+        UtcTimestamp = new(utcTimestamp, TimeSpan.Zero);
+        TimeZoneId = timeZoneId;
+    }
+
+    public void Deconstruct(out DateTimeOffset utcTimestamp, out string timeZoneId)
+    {
+        utcTimestamp = UtcTimestamp;
+        timeZoneId = TimeZoneId;
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/TimestampTzExpressionInterceptorTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/TimestampTzExpressionInterceptorTests.cs
@@ -1,0 +1,78 @@
+using System.Linq.Expressions;
+using FluentAssertions;
+using LeanCode.DomainModels.Model;
+using Xunit;
+
+namespace LeanCode.DomainModels.EF.Tests;
+
+public class TimestampTzExpressionInterceptorTests
+{
+    [Fact]
+    public void LocalTimestampWithoutOffsetProperty_accesses_expected_property()
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, "Europe/Warsaw");
+
+        TimestampTzExpressionRewriter.LocalTimestampWithoutOffsetProperty
+            .GetGetMethod()
+            .Invoke(timestampTz, null)
+            .Should()
+            .Be(timestampTz.LocalTimestampWithoutOffset);
+    }
+
+    [Fact]
+    public void UtcTimestampProperty_accesses_expected_property()
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, "Europe/Warsaw");
+
+        TimestampTzExpressionRewriter.UtcTimestampProperty
+            .GetGetMethod()
+            .Invoke(timestampTz, null)
+            .Should()
+            .Be(timestampTz.UtcTimestamp);
+    }
+
+    [Fact]
+    public void TimeZoneIdProperty_accesses_expected_property()
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, "Europe/Warsaw");
+
+        TimestampTzExpressionRewriter.TimeZoneIdProperty
+            .GetGetMethod()
+            .Invoke(timestampTz, null)
+            .Should()
+            .Be(timestampTz.TimeZoneId);
+    }
+
+    [Fact]
+    public void UtcDateTimeProperty_accesses_expected_property()
+    {
+        var dto = DateTimeOffset.Now;
+
+        TimestampTzExpressionRewriter.UtcDateTimeProperty.GetGetMethod().Invoke(dto, null).Should().Be(dto.UtcDateTime);
+    }
+
+    [Fact]
+    public void ConvertDateTimeBySystemTimeZoneIdMethod_calls_expected_method()
+    {
+        var utcNow = DateTime.UtcNow;
+
+        TimestampTzExpressionRewriter.ConvertDateTimeBySystemTimeZoneIdMethod
+            .Invoke(null, [ utcNow, "Europe/Warsaw" ])
+            .Should()
+            .Be(TimeZoneInfo.ConvertTimeBySystemTimeZoneId(utcNow, "Europe/Warsaw"));
+    }
+
+    [Fact]
+    public void Interceptor_rewrites_expression_tree_as_expected()
+    {
+        Expression input = (TimestampTz tstz) => tstz.LocalTimestampWithoutOffset;
+
+        Expression expectedOutput = (TimestampTz tstz) =>
+            TimeZoneInfo.ConvertTimeBySystemTimeZoneId(tstz.UtcTimestamp.UtcDateTime, tstz.TimeZoneId);
+
+        TimestampTzExpressionInterceptorDbContextOptionsBuilderExtensions.Interceptor
+            .QueryCompilationStarting(input, default)
+            .Should()
+            .BeEquivalentTo(expectedOutput);
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.Tests/Model/TimestampTzTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Model/TimestampTzTests.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using FluentAssertions;
+using LeanCode.DomainModels.Model;
+using Xunit;
+
+namespace LeanCode.DomainModels.Tests.Model;
+
+public class TimestampTzTests
+{
+    [Theory]
+    [InlineData("UTC")]
+    [InlineData("Etc/UTC")]
+    [InlineData("Etc/GMT")]
+    [InlineData("Europe/Warsaw")]
+    [InlineData("Central European Standard Time")]
+    public void Both_IANA_and_Windows_time_zone_ids_are_valid(string timeZoneId)
+    {
+        AssertionExtensions.Should(TimestampTz.IsValidTimeZoneId(timeZoneId)).BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("invalid")]
+    public void Invalid_time_zone_ids_are_rejected(string timeZoneId)
+    {
+        AssertionExtensions.Should(TimestampTz.IsValidTimeZoneId(timeZoneId)).BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Etc/UTC")]
+    [InlineData("Etc/GMT")]
+    [InlineData("Europe/Warsaw")]
+    public void IANA_time_zone_ids_are_preserved_as_passed(string timeZoneId)
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, timeZoneId);
+
+        AssertionExtensions.Should(timestampTz.TimeZoneId).Be(timeZoneId);
+        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+    }
+
+    [Theory]
+    [InlineData("Etc/UTC")]
+    [InlineData("Etc/GMT")]
+    [InlineData("Europe/Warsaw")]
+    public void IANA_time_zone_infos_are_preserved_as_passed(string timeZoneId)
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+
+        AssertionExtensions.Should(timestampTz.TimeZoneId).Be(timeZoneId);
+        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+    }
+
+    [Fact]
+    public void UTC_time_zone_id_is_normalized_to_Etc_UTC()
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, TimeZoneInfo.Utc.Id);
+
+        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Etc/UTC");
+        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"));
+    }
+
+    [Fact]
+    public void UTC_time_zone_info_is_normalized_to_Etc_UTC()
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, TimeZoneInfo.Utc);
+
+        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Etc/UTC");
+        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"));
+    }
+
+    [Fact]
+    public void Windows_time_zone_ids_are_converted_to_IANA_ids()
+    {
+        var timestampTz = new TimestampTz(DateTime.UtcNow, "Central European Standard Time");
+
+        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Europe/Warsaw");
+        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"));
+    }
+
+    [Fact]
+    public void Windows_time_zone_infos_are_converted_to_IANA_ids()
+    {
+        var timestampTz = new TimestampTz(
+            DateTime.UtcNow,
+            TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time")
+        );
+
+        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Europe/Warsaw");
+        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("invalid")]
+    public void Invalid_time_zone_ids_throw_exception(string timeZoneId)
+    {
+        AssertionExtensions
+            .Should(() => new TimestampTz(DateTime.UtcNow, timeZoneId))
+            .Throw<TimeZoneNotFoundException>();
+    }
+
+    [Fact]
+    public void Non_UTC_DateTime_timestamps_throw_exception()
+    {
+        AssertionExtensions.Should(() => new TimestampTz(DateTime.Now, "Etc/UTC")).Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Non_UTC_DateTimeOffset_timestamps_are_converted_to_UTC(bool useTimeZoneInfo)
+    {
+        var now = DateTimeOffset.Now;
+
+        var timestampTz = useTimeZoneInfo
+            ? new TimestampTz(now, TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"))
+            : new TimestampTz(now, "Etc/UTC");
+
+        AssertionExtensions.Should(timestampTz.UtcTimestamp).Be(now.UtcDateTime);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Local_timestamps_are_correctly_calculated(bool useTimeZoneInfo)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var nowInWarsaw = TimeZoneInfo.ConvertTimeBySystemTimeZoneId(now, "Europe/Warsaw");
+
+        var timestampTz = useTimeZoneInfo
+            ? new TimestampTz(now, TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"))
+            : new TimestampTz(now, "Europe/Warsaw");
+
+        AssertionExtensions.Should(timestampTz.LocalTimestampWithOffset).Be(nowInWarsaw);
+        AssertionExtensions.Should(timestampTz.LocalTimestampWithoutOffset).Be(nowInWarsaw.DateTime);
+    }
+
+    [Fact]
+    public void Deconstruction_roundtrips()
+    {
+        var source = new TimestampTz(DateTime.UtcNow, "Europe/Warsaw");
+        var (timestamp, timeZoneId) = source;
+        var reconstructed = new TimestampTz(timestamp, timeZoneId);
+
+        AssertionExtensions.Should(reconstructed).Be(source);
+    }
+
+    [Fact]
+    public void Json_serialization_writes_expected_properties()
+    {
+        var serialized = JsonSerializer.Serialize(new TimestampTz(DateTime.UtcNow, "Europe/Warsaw"));
+
+        // {"UtcTimestamp":"2009-06-15T13:45:30.0000000+00:00","TimeZoneId":"Europe/Warsaw"}
+        using var document = JsonDocument.Parse(serialized);
+
+        AssertionExtensions.Should(document.RootElement.ValueKind).Be(JsonValueKind.Object);
+        AssertionExtensions
+            .Should(document.RootElement.EnumerateObject())
+            .BeEquivalentTo(
+                [
+                    new { Name = nameof(TimestampTz.UtcTimestamp), Value = new { ValueKind = JsonValueKind.String } },
+                    new { Name = nameof(TimestampTz.TimeZoneId), Value = new { ValueKind = JsonValueKind.String } },
+                ],
+                options => options.WithStrictOrdering()
+            );
+    }
+
+    [Fact]
+    public void Json_serialization_roundtrips()
+    {
+        var source = new TimestampTz(DateTime.UtcNow, "Europe/Warsaw");
+        var serialized = JsonSerializer.Serialize(source);
+        var deserialized = JsonSerializer.Deserialize<TimestampTz>(serialized)!;
+
+        AssertionExtensions.Should(deserialized).NotBeNull();
+        AssertionExtensions.Should(deserialized.TimeZoneId).Be(source.TimeZoneId);
+        AssertionExtensions.Should(deserialized.UtcTimestamp).Be(source.UtcTimestamp);
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.Tests/Model/TimestampTzTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Model/TimestampTzTests.cs
@@ -15,7 +15,7 @@ public class TimestampTzTests
     [InlineData("Central European Standard Time")]
     public void Both_IANA_and_Windows_time_zone_ids_are_valid(string timeZoneId)
     {
-        AssertionExtensions.Should(TimestampTz.IsValidTimeZoneId(timeZoneId)).BeTrue();
+        TimestampTz.IsValidTimeZoneId(timeZoneId).Should().BeTrue();
     }
 
     [Theory]
@@ -23,7 +23,7 @@ public class TimestampTzTests
     [InlineData("invalid")]
     public void Invalid_time_zone_ids_are_rejected(string timeZoneId)
     {
-        AssertionExtensions.Should(TimestampTz.IsValidTimeZoneId(timeZoneId)).BeFalse();
+        TimestampTz.IsValidTimeZoneId(timeZoneId).Should().BeFalse();
     }
 
     [Theory]
@@ -34,8 +34,8 @@ public class TimestampTzTests
     {
         var timestampTz = new TimestampTz(DateTime.UtcNow, timeZoneId);
 
-        AssertionExtensions.Should(timestampTz.TimeZoneId).Be(timeZoneId);
-        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+        timestampTz.TimeZoneId.Should().Be(timeZoneId);
+        timestampTz.TimeZoneInfo.Should().Be(TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
     }
 
     [Theory]
@@ -46,8 +46,8 @@ public class TimestampTzTests
     {
         var timestampTz = new TimestampTz(DateTime.UtcNow, TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
 
-        AssertionExtensions.Should(timestampTz.TimeZoneId).Be(timeZoneId);
-        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+        timestampTz.TimeZoneId.Should().Be(timeZoneId);
+        timestampTz.TimeZoneInfo.Should().Be(TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public class TimestampTzTests
     {
         var timestampTz = new TimestampTz(DateTime.UtcNow, TimeZoneInfo.Utc.Id);
 
-        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Etc/UTC");
-        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"));
+        timestampTz.TimeZoneId.Should().Be("Etc/UTC");
+        timestampTz.TimeZoneInfo.Should().Be(TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"));
     }
 
     [Fact]
@@ -64,8 +64,8 @@ public class TimestampTzTests
     {
         var timestampTz = new TimestampTz(DateTime.UtcNow, TimeZoneInfo.Utc);
 
-        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Etc/UTC");
-        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"));
+        timestampTz.TimeZoneId.Should().Be("Etc/UTC");
+        timestampTz.TimeZoneInfo.Should().Be(TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"));
     }
 
     [Fact]
@@ -73,8 +73,8 @@ public class TimestampTzTests
     {
         var timestampTz = new TimestampTz(DateTime.UtcNow, "Central European Standard Time");
 
-        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Europe/Warsaw");
-        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"));
+        timestampTz.TimeZoneId.Should().Be("Europe/Warsaw");
+        timestampTz.TimeZoneInfo.Should().Be(TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"));
     }
 
     [Fact]
@@ -85,8 +85,8 @@ public class TimestampTzTests
             TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time")
         );
 
-        AssertionExtensions.Should(timestampTz.TimeZoneId).Be("Europe/Warsaw");
-        AssertionExtensions.Should(timestampTz.TimeZoneInfo).Be(TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"));
+        timestampTz.TimeZoneId.Should().Be("Europe/Warsaw");
+        timestampTz.TimeZoneInfo.Should().Be(TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"));
     }
 
     [Theory]
@@ -94,15 +94,15 @@ public class TimestampTzTests
     [InlineData("invalid")]
     public void Invalid_time_zone_ids_throw_exception(string timeZoneId)
     {
-        AssertionExtensions
-            .Should(() => new TimestampTz(DateTime.UtcNow, timeZoneId))
-            .Throw<TimeZoneNotFoundException>();
+        var act = () => new TimestampTz(DateTime.UtcNow, timeZoneId);
+        act.Should().Throw<TimeZoneNotFoundException>();
     }
 
     [Fact]
     public void Non_UTC_DateTime_timestamps_throw_exception()
     {
-        AssertionExtensions.Should(() => new TimestampTz(DateTime.Now, "Etc/UTC")).Throw<ArgumentException>();
+        var act = () => new TimestampTz(DateTime.Now, "Etc/UTC");
+        act.Should().Throw<ArgumentException>();
     }
 
     [Theory]
@@ -116,7 +116,7 @@ public class TimestampTzTests
             ? new TimestampTz(now, TimeZoneInfo.FindSystemTimeZoneById("Etc/UTC"))
             : new TimestampTz(now, "Etc/UTC");
 
-        AssertionExtensions.Should(timestampTz.UtcTimestamp).Be(now.UtcDateTime);
+        timestampTz.UtcTimestamp.Should().Be(now.UtcDateTime);
     }
 
     [Theory]
@@ -131,8 +131,8 @@ public class TimestampTzTests
             ? new TimestampTz(now, TimeZoneInfo.FindSystemTimeZoneById("Europe/Warsaw"))
             : new TimestampTz(now, "Europe/Warsaw");
 
-        AssertionExtensions.Should(timestampTz.LocalTimestampWithOffset).Be(nowInWarsaw);
-        AssertionExtensions.Should(timestampTz.LocalTimestampWithoutOffset).Be(nowInWarsaw.DateTime);
+        timestampTz.LocalTimestampWithOffset.Should().Be(nowInWarsaw);
+        timestampTz.LocalTimestampWithoutOffset.Should().Be(nowInWarsaw.DateTime);
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class TimestampTzTests
         var (timestamp, timeZoneId) = source;
         var reconstructed = new TimestampTz(timestamp, timeZoneId);
 
-        AssertionExtensions.Should(reconstructed).Be(source);
+        reconstructed.Should().Be(source);
     }
 
     [Fact]
@@ -153,9 +153,10 @@ public class TimestampTzTests
         // {"UtcTimestamp":"2009-06-15T13:45:30.0000000+00:00","TimeZoneId":"Europe/Warsaw"}
         using var document = JsonDocument.Parse(serialized);
 
-        AssertionExtensions.Should(document.RootElement.ValueKind).Be(JsonValueKind.Object);
-        AssertionExtensions
-            .Should(document.RootElement.EnumerateObject())
+        document.RootElement.ValueKind.Should().Be(JsonValueKind.Object);
+        document.RootElement
+            .EnumerateObject()
+            .Should()
             .BeEquivalentTo(
                 [
                     new { Name = nameof(TimestampTz.UtcTimestamp), Value = new { ValueKind = JsonValueKind.String } },
@@ -172,8 +173,8 @@ public class TimestampTzTests
         var serialized = JsonSerializer.Serialize(source);
         var deserialized = JsonSerializer.Deserialize<TimestampTz>(serialized)!;
 
-        AssertionExtensions.Should(deserialized).NotBeNull();
-        AssertionExtensions.Should(deserialized.TimeZoneId).Be(source.TimeZoneId);
-        AssertionExtensions.Should(deserialized.UtcTimestamp).Be(source.UtcTimestamp);
+        deserialized.Should().NotBeNull();
+        deserialized.TimeZoneId.Should().Be(source.TimeZoneId);
+        deserialized.UtcTimestamp.Should().Be(source.UtcTimestamp);
     }
 }

--- a/test/LeanCode.IntegrationTests/App/Meeting.cs
+++ b/test/LeanCode.IntegrationTests/App/Meeting.cs
@@ -1,0 +1,10 @@
+using LeanCode.DomainModels.Model;
+
+namespace LeanCode.IntegrationTests.App;
+
+public class Meeting
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = default!;
+    public TimestampTz StartTime { get; set; } = default!;
+}

--- a/test/LeanCode.IntegrationTests/App/TestDbContext.cs
+++ b/test/LeanCode.IntegrationTests/App/TestDbContext.cs
@@ -7,6 +7,7 @@ namespace LeanCode.IntegrationTests.App;
 public class TestDbContext : DbContext
 {
     public DbSet<Entity> Entities => Set<Entity>();
+    public DbSet<Meeting> Meetings => Set<Meeting>();
     public DbSet<PushNotificationTokenEntity<Guid>> Tokens => Set<PushNotificationTokenEntity<Guid>>();
 
     public TestDbContext(DbContextOptions<TestDbContext> opts)
@@ -18,6 +19,12 @@ public class TestDbContext : DbContext
         {
             cfg.HasKey(e => e.Id);
             cfg.Property(e => e.Value).HasMaxLength(100);
+        });
+
+        modelBuilder.Entity<Meeting>(cfg =>
+        {
+            cfg.HasKey(e => e.Id);
+            cfg.OwnsOne(e => e.StartTime);
         });
 
         modelBuilder.AddInboxStateEntity();

--- a/test/LeanCode.IntegrationTests/PostgresFactAttribute.cs
+++ b/test/LeanCode.IntegrationTests/PostgresFactAttribute.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace LeanCode.IntegrationTests;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class PostgresFactAttribute : FactAttribute
+{
+    public PostgresFactAttribute()
+    {
+        if (Environment.GetEnvironmentVariable(TestDatabaseConfig.ConfigEnvName) != "postgres")
+        {
+            Skip = "Not running against PostgreSQL.";
+        }
+    }
+}

--- a/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
+++ b/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
@@ -1,4 +1,5 @@
 using LeanCode.CQRS.MassTransitRelay.LockProviders;
+using LeanCode.DomainModels.EF;
 using LeanCode.IntegrationTestHelpers;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
@@ -53,7 +54,7 @@ public class PostgresTestConfig : TestDatabaseConfig
     public override void ConfigureDbContext(DbContextOptionsBuilder builder, IConfiguration config)
     {
         var dataSource = new NpgsqlDataSourceBuilder(config.GetValue<string>("Postgres:ConnectionString")).Build();
-        builder.UseNpgsql(dataSource);
+        builder.UseNpgsql(dataSource).AddTimestampTzExpressionInterceptor();
     }
 
     public override void ConfigureMassTransitOutbox(IEntityFrameworkOutboxConfigurator configurator)

--- a/test/LeanCode.IntegrationTests/TimestampTzTests.cs
+++ b/test/LeanCode.IntegrationTests/TimestampTzTests.cs
@@ -43,9 +43,7 @@ public class TimestampTzTests : IAsyncLifetime
     {
         var orderedByUtc = await dbContext.Meetings.OrderBy(m => m.StartTime.UtcTimestamp).ToListAsync();
 
-        AssertionExtensions
-            .Should(orderedByUtc)
-            .BeEquivalentTo([ meeting1, meeting2 ], options => options.WithStrictOrdering());
+        orderedByUtc.Should().BeEquivalentTo([ meeting1, meeting2 ], options => options.WithStrictOrdering());
     }
 
     [PostgresFact]
@@ -55,18 +53,16 @@ public class TimestampTzTests : IAsyncLifetime
             .OrderBy(m => m.StartTime.LocalTimestampWithoutOffset)
             .ToListAsync();
 
-        AssertionExtensions
-            .Should(orderedByLocal)
-            .BeEquivalentTo([ meeting2, meeting1 ], options => options.WithStrictOrdering());
+        orderedByLocal.Should().BeEquivalentTo([ meeting2, meeting1 ], options => options.WithStrictOrdering());
     }
 
     [PostgresFact]
     public void Sorting_by_LocalTimestampWithoutOffset_generates_SQL_with_expected_AT_TIME_ZONE_operator()
     {
-        var sql = dbContext.Meetings.OrderBy(m => m.StartTime.LocalTimestampWithoutOffset).ToQueryString();
-
-        AssertionExtensions
-            .Should(sql)
+        dbContext.Meetings
+            .OrderBy(m => m.StartTime.LocalTimestampWithoutOffset)
+            .ToQueryString()
+            .Should()
             .ContainEquivalentOf(
                 @$"ORDER BY m.""{nameof(Meeting.StartTime)}_{nameof(TimestampTz.UtcTimestamp)}"" AT TIME ZONE m.""{nameof(Meeting.StartTime)}_{nameof(TimestampTz.TimeZoneId)}"""
             );

--- a/test/LeanCode.IntegrationTests/TimestampTzTests.cs
+++ b/test/LeanCode.IntegrationTests/TimestampTzTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using LeanCode.DomainModels.Model;
+using LeanCode.IntegrationTests.App;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace LeanCode.IntegrationTests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("?", "CA1001", Justification = "Disposed with `IAsyncLifetime`.")]
+public class TimestampTzTests : IAsyncLifetime
+{
+    private static readonly DateOnly Date = new(2023, 10, 5);
+
+    private readonly TestApp app;
+
+    private readonly Meeting meeting1 =
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "First",
+            StartTime = new(Date.ToDateTime(new(10, 0), DateTimeKind.Utc), "Asia/Tokyo")
+        };
+
+    private readonly Meeting meeting2 =
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Second",
+            StartTime = new(Date.ToDateTime(new(14, 0), DateTimeKind.Utc), "America/Los_Angeles")
+        };
+
+    private TestDbContext dbContext;
+
+    public TimestampTzTests()
+    {
+        app = new TestApp();
+        dbContext = null!;
+    }
+
+    [PostgresFact]
+    public async Task Sorting_by_UtcTimestamp_returns_results_in_expected_order()
+    {
+        var orderedByUtc = await dbContext.Meetings.OrderBy(m => m.StartTime.UtcTimestamp).ToListAsync();
+
+        AssertionExtensions
+            .Should(orderedByUtc)
+            .BeEquivalentTo([ meeting1, meeting2 ], options => options.WithStrictOrdering());
+    }
+
+    [PostgresFact]
+    public async Task Sorting_by_LocalTimestampWithoutOffset_returns_results_in_expected_order()
+    {
+        var orderedByLocal = await dbContext.Meetings
+            .OrderBy(m => m.StartTime.LocalTimestampWithoutOffset)
+            .ToListAsync();
+
+        AssertionExtensions
+            .Should(orderedByLocal)
+            .BeEquivalentTo([ meeting2, meeting1 ], options => options.WithStrictOrdering());
+    }
+
+    [PostgresFact]
+    public void Sorting_by_LocalTimestampWithoutOffset_generates_SQL_with_expected_AT_TIME_ZONE_operator()
+    {
+        var sql = dbContext.Meetings.OrderBy(m => m.StartTime.LocalTimestampWithoutOffset).ToQueryString();
+
+        AssertionExtensions
+            .Should(sql)
+            .ContainEquivalentOf(
+                @$"ORDER BY m.""{nameof(Meeting.StartTime)}_{nameof(TimestampTz.UtcTimestamp)}"" AT TIME ZONE m.""{nameof(Meeting.StartTime)}_{nameof(TimestampTz.TimeZoneId)}"""
+            );
+    }
+
+    public async Task InitializeAsync()
+    {
+        await app.InitializeAsync();
+
+        dbContext = app.Services.GetRequiredService<TestDbContext>();
+
+        dbContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
+
+        dbContext.Meetings.Add(meeting1);
+        dbContext.Meetings.Add(meeting2);
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    public Task DisposeAsync() => app.DisposeAsync().AsTask();
+}

--- a/test/LeanCode.IntegrationTests/docker/docker-compose.yml
+++ b/test/LeanCode.IntegrationTests/docker/docker-compose.yml
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S docker compose -f
 version: "3.6"
 services:
   #### Tests
@@ -9,10 +10,12 @@ services:
       - ../../..:/app/code
       - ~/.nuget:/home/dotnet/.nuget
     environment:
-      - SqlServer__ConnectionStringBase=Server=db,1433;User Id=sa;Password=Passw12#;Encrypt=false
-      - WAIT_FOR_DEBUGGER=${WAIT_FOR_DEBUGGER:-}
+      LeanCodeIntegrationTests__Database: ${DB:?}
+      SqlServer__ConnectionStringBase: Server=sqlserver;User Id=sa;Password=Passw12#;Encrypt=false
+      Postgres__ConnectionStringBase: Host=postgres;Username=postgres;Password=Passw12#;SSL Mode=Disable
+      WAIT_FOR_DEBUGGER: ${WAIT_FOR_DEBUGGER:-}
     depends_on:
-      - db
+      - ${DB:?}
 
   watch_test:
     build:
@@ -22,21 +25,24 @@ services:
       - ../../..:/app/code
       - ~/.nuget:/home/dotnet/.nuget
     environment:
-      - SqlServer__ConnectionStringBase=Server=db,1433;User Id=sa;Password=Passw12#;Encrypt=false
-      - WAIT_FOR_DEBUGGER=${WAIT_FOR_DEBUGGER:-}
+      LeanCodeIntegrationTests__Database: ${DB:?}
+      SqlServer__ConnectionStringBase: Server=sqlserver;User Id=sa;Password=Passw12#;Encrypt=false
+      Postgres__ConnectionStringBase: Host=postgres;Username=postgres;Password=Passw12#;SSL Mode=Disable
+      WAIT_FOR_DEBUGGER: ${WAIT_FOR_DEBUGGER:-}
     depends_on:
-      - db
+      - ${DB:?}
 
   #### Infrastructure
-  db:
+  sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=Passw12#
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: Passw12#
     ports:
       - "1433:1433"
+
   postgres:
-    image: postgres:14
+    image: postgres:15
     environment:
       POSTGRES_PASSWORD: Passw12#
     ports:


### PR DESCRIPTION
`TimestampTzLocalTimestampExpressionInterceptor` is there for ease of use, allowing access to `LocalTimestamp` property by translating it to `"UtcTimestamp" AT TIME ZONE "TimeZoneId"` in queries. Of course, we don't have access to the offset this way so care should be taken to use `GetLocalTimestampWithOffset()` when offset is actually needed (that will be evaulated client-side).

Creating indexes on columns corresponding to members of `OwnsOne`'d types is still a bit of a pain but should be doable with raw SQL in migrations.

I believe this + something like `Microsoft.CodeAnalysis.BannedApiAnalyzers` configured to forbid use of implicit cast of `DateTime` to `DateTimeOffset` (when mapping to DTOs) should be enough to cover most of our use cases.