### PR TITLE
Add initiator to identity trace attributes

### DIFF
--- a/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesFromBaggageProcessor.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesFromBaggageProcessor.cs
@@ -7,28 +7,28 @@ public class IdentityTraceAttributesFromBaggageProcessor : BaseProcessor<Activit
 {
     public override void OnEnd(Activity data)
     {
-        if (data.GetBaggageItem(IdentityTraceBaggageHelpers.UserIdKey) is { } userId)
+        if (data.GetBaggageItem(IdentityTraceBaggageHelpers.CurrentUserIdKey) is { } userId)
         {
-            data.SetTag(IdentityTraceBaggageHelpers.UserIdKey, userId);
+            data.SetTag(IdentityTraceBaggageHelpers.CurrentUserIdKey, userId);
         }
 
-        if (data.GetBaggageItem(IdentityTraceBaggageHelpers.InitiatorIdKey) is { } initiatorId)
+        if (data.GetBaggageItem(IdentityTraceBaggageHelpers.EndUserIdKey) is { } initiatorId)
         {
-            data.SetTag(IdentityTraceBaggageHelpers.InitiatorIdKey, initiatorId);
+            data.SetTag(IdentityTraceBaggageHelpers.EndUserIdKey, initiatorId);
         }
 
-        var roles = data.GetUserRoleBaggage(IdentityTraceBaggageHelpers.UserRoleKey);
+        var roles = data.GetUserRoleBaggage(IdentityTraceBaggageHelpers.CurrentUserRoleKey);
 
         if (roles is not null)
         {
-            data.SetTag(IdentityTraceBaggageHelpers.UserRoleKey, roles);
+            data.SetTag(IdentityTraceBaggageHelpers.CurrentUserRoleKey, roles);
         }
 
-        var initiatorRoles = data.GetUserRoleBaggage(IdentityTraceBaggageHelpers.InitiatorRoleKey);
+        var initiatorRoles = data.GetUserRoleBaggage(IdentityTraceBaggageHelpers.EndUserRoleKey);
 
         if (initiatorRoles is not null)
         {
-            data.SetTag(IdentityTraceBaggageHelpers.InitiatorRoleKey, initiatorRoles);
+            data.SetTag(IdentityTraceBaggageHelpers.EndUserRoleKey, initiatorRoles);
         }
     }
 }

--- a/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesFromBaggageProcessor.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesFromBaggageProcessor.cs
@@ -12,11 +12,23 @@ public class IdentityTraceAttributesFromBaggageProcessor : BaseProcessor<Activit
             data.SetTag(IdentityTraceBaggageHelpers.UserIdKey, userId);
         }
 
-        var roles = data.GetUserRoleBaggage();
+        if (data.GetBaggageItem(IdentityTraceBaggageHelpers.InitiatorIdKey) is { } initiatorId)
+        {
+            data.SetTag(IdentityTraceBaggageHelpers.InitiatorIdKey, initiatorId);
+        }
+
+        var roles = data.GetUserRoleBaggage(IdentityTraceBaggageHelpers.UserRoleKey);
 
         if (roles is not null)
         {
-            data.SetTag(IdentityTraceBaggageHelpers.RoleKey, roles);
+            data.SetTag(IdentityTraceBaggageHelpers.UserRoleKey, roles);
+        }
+
+        var initiatorRoles = data.GetUserRoleBaggage(IdentityTraceBaggageHelpers.InitiatorRoleKey);
+
+        if (initiatorRoles is not null)
+        {
+            data.SetTag(IdentityTraceBaggageHelpers.InitiatorRoleKey, initiatorRoles);
         }
     }
 }

--- a/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesMiddleware.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesMiddleware.cs
@@ -18,19 +18,28 @@ public static class IdentityTraceAttributesMiddleware
                 if ((httpContext.User.Identity?.IsAuthenticated ?? false) && Activity.Current is Activity activity)
                 {
                     if (
-                        activity.GetBaggageItem(IdentityTraceBaggageHelpers.UserIdKey) is null
-                        && httpContext.User.FindFirstValue(userIdClaim) is string userId
+                        httpContext.User.FindFirstValue(userIdClaim) is string userId
                         && !string.IsNullOrWhiteSpace(userId)
                     )
                     {
                         activity.AddBaggage(IdentityTraceBaggageHelpers.UserIdKey, userId);
+
+                        if (activity.GetBaggageItem(IdentityTraceBaggageHelpers.InitiatorIdKey) is null)
+                        {
+                            activity.AddBaggage(IdentityTraceBaggageHelpers.InitiatorIdKey, userId);
+                        }
                     }
 
                     var userRoles = httpContext.User.Claims.Where(c => c.Type == roleClaim).Select(c => c.Value);
 
-                    if (activity.GetBaggageItem(IdentityTraceBaggageHelpers.RoleKey) is null && userRoles.Any())
+                    if (userRoles.Any())
                     {
-                        activity.SetUserRoleBaggage(userRoles);
+                        activity.SetUserRoleBaggage(IdentityTraceBaggageHelpers.UserRoleKey, userRoles);
+
+                        if (activity.GetBaggageItem(IdentityTraceBaggageHelpers.InitiatorRoleKey) is null)
+                        {
+                            activity.SetUserRoleBaggage(IdentityTraceBaggageHelpers.InitiatorRoleKey, userRoles);
+                        }
                     }
                 }
 

--- a/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesMiddleware.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceAttributesMiddleware.cs
@@ -22,11 +22,11 @@ public static class IdentityTraceAttributesMiddleware
                         && !string.IsNullOrWhiteSpace(userId)
                     )
                     {
-                        activity.AddBaggage(IdentityTraceBaggageHelpers.UserIdKey, userId);
+                        activity.AddBaggage(IdentityTraceBaggageHelpers.CurrentUserIdKey, userId);
 
-                        if (activity.GetBaggageItem(IdentityTraceBaggageHelpers.InitiatorIdKey) is null)
+                        if (activity.GetBaggageItem(IdentityTraceBaggageHelpers.EndUserIdKey) is null)
                         {
-                            activity.AddBaggage(IdentityTraceBaggageHelpers.InitiatorIdKey, userId);
+                            activity.AddBaggage(IdentityTraceBaggageHelpers.EndUserIdKey, userId);
                         }
                     }
 
@@ -34,11 +34,11 @@ public static class IdentityTraceAttributesMiddleware
 
                     if (userRoles.Any())
                     {
-                        activity.SetUserRoleBaggage(IdentityTraceBaggageHelpers.UserRoleKey, userRoles);
+                        activity.SetUserRoleBaggage(IdentityTraceBaggageHelpers.CurrentUserRoleKey, userRoles);
 
-                        if (activity.GetBaggageItem(IdentityTraceBaggageHelpers.InitiatorRoleKey) is null)
+                        if (activity.GetBaggageItem(IdentityTraceBaggageHelpers.EndUserRoleKey) is null)
                         {
-                            activity.SetUserRoleBaggage(IdentityTraceBaggageHelpers.InitiatorRoleKey, userRoles);
+                            activity.SetUserRoleBaggage(IdentityTraceBaggageHelpers.EndUserRoleKey, userRoles);
                         }
                     }
                 }

--- a/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceBaggageHelpers.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceBaggageHelpers.cs
@@ -5,10 +5,10 @@ namespace LeanCode.OpenTelemetry;
 
 public static class IdentityTraceBaggageHelpers
 {
-    public const string UserIdKey = "enduser.id";
-    public const string UserRoleKey = "enduser.role";
-    public const string InitiatorIdKey = "initiator.id";
-    public const string InitiatorRoleKey = "initiator.role";
+    public const string CurrentUserIdKey = "current_user.id";
+    public const string CurrentUserRoleKey = "current_user.role";
+    public const string EndUserIdKey = "enduser.id";
+    public const string EndUserRoleKey = "enduser.role";
 
     public static void SetUserRoleBaggage(this Activity activity, string roleKey, IEnumerable<string> roles)
     {

--- a/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceBaggageHelpers.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/IdentityTraceBaggageHelpers.cs
@@ -6,17 +6,19 @@ namespace LeanCode.OpenTelemetry;
 public static class IdentityTraceBaggageHelpers
 {
     public const string UserIdKey = "enduser.id";
-    public const string RoleKey = "enduser.role";
+    public const string UserRoleKey = "enduser.role";
+    public const string InitiatorIdKey = "initiator.id";
+    public const string InitiatorRoleKey = "initiator.role";
 
-    public static void SetUserRoleBaggage(this Activity activity, IEnumerable<string> roles)
+    public static void SetUserRoleBaggage(this Activity activity, string roleKey, IEnumerable<string> roles)
     {
         var rolesJson = JsonSerializer.Serialize(roles);
-        activity.AddBaggage(RoleKey, rolesJson);
+        activity.AddBaggage(roleKey, rolesJson);
     }
 
-    public static IEnumerable<string>? GetUserRoleBaggage(this Activity activity)
+    public static IEnumerable<string>? GetUserRoleBaggage(this Activity activity, string roleKey)
     {
-        var rolesJson = activity.GetBaggageItem(RoleKey);
+        var rolesJson = activity.GetBaggageItem(roleKey);
 
         if (rolesJson is null)
         {


### PR DESCRIPTION
The reasoning behind the change is that we need to relay on the actual user (eg `System` in internal calls) but we want to preserve the first user who performed an action (called `initiator`).