### PR TITLE
Add helpers that allow loading tracked entites directly from context [COR-121]

### DIFF
--- a/src/Domain/LeanCode.DomainModels.EF/CachingEFRepository.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/CachingEFRepository.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using LeanCode.DomainModels.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace LeanCode.DomainModels.EF;
+
+public abstract class CachingEFRepository<TEntity, TIdentity, TContext> : EFRepository<TEntity, TIdentity, TContext>
+    where TEntity : class, IAggregateRootWithoutOptimisticConcurrency<TIdentity>
+    where TIdentity : notnull
+    where TContext : DbContext
+{
+    protected CachingEFRepository(TContext dbContext)
+        : base(dbContext) { }
+
+    /// <summary>
+    /// Finds an entity by primary key. If the entity with provided key is tracked by the underlying
+    /// <see cref="DbContext" />, this method will return the cached entity.
+    /// </summary>
+    /// <remarks>For implementers: the default implementation won't work for composite primary keys.</remarks>
+    /// <param name="id">The identifier that</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>Task with the found entity, or -null- if not found.</returns>
+    public override async Task<TEntity?> FindAsync(TIdentity id, CancellationToken cancellationToken = default)
+    {
+        return await FindTrackedOrLoadNewAsync(
+            id,
+            _ => BaseQuery().AsTracking().FirstOrDefaultAsync(e => e.Id.Equals(id), cancellationToken)
+        );
+    }
+
+    [SuppressMessage(
+        "?",
+        "EF1001",
+        Justification = "This is basically the `EntityFinder.FindTracked` to mimic `FindAsync` snapshot re-use."
+    )]
+    protected TEntity? FindTracked(TIdentity id)
+    {
+        // Safety: aggregates are bound to have Id as a primary key by design.
+        var primaryKey = DbContext.Model.FindEntityType(typeof(TEntity))!.FindPrimaryKey()!;
+        return ((IDbContextDependencies)DbContext).StateManager!.TryGetEntryTyped(primaryKey, id)?.Entity as TEntity;
+    }
+
+    [SuppressMessage(
+        "?",
+        "EF1001",
+        Justification = "This is basically the `EntityFinder.FindTracked` to mimic `FindAsync` snapshot re-use."
+    )]
+    protected TEntity? FindTracked(params object[] id)
+    {
+        // Safety: aggregates are bound to have Id as a primary key by design.
+        var primaryKey = DbContext.Model.FindEntityType(typeof(TEntity))!.FindPrimaryKey()!;
+        return ((IDbContextDependencies)DbContext).StateManager!.TryGetEntryTyped(primaryKey, id)?.Entity as TEntity;
+    }
+
+    protected ValueTask<TEntity?> FindTrackedOrLoadNewAsync(TIdentity id, Func<DbSet<TEntity>, Task<TEntity?>> query)
+    {
+        var tracked = FindTracked(id);
+        return tracked is not null ? new(tracked) : new(query(DbSet));
+    }
+
+    protected ValueTask<TEntity?> FindTrackedOrLoadNewAsync(object[] id, Func<DbSet<TEntity>, Task<TEntity?>> query)
+    {
+        var tracked = FindTracked(id);
+        return tracked is not null ? new(tracked) : new(query(DbSet));
+    }
+}

--- a/src/Domain/LeanCode.DomainModels.EF/CachingEFRepository.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/CachingEFRepository.cs
@@ -13,14 +13,11 @@ public abstract class CachingEFRepository<TEntity, TIdentity, TContext> : EFRepo
     protected CachingEFRepository(TContext dbContext)
         : base(dbContext) { }
 
+    /// <inheritdoc />
     /// <summary>
     /// Finds an entity by primary key. If the entity with provided key is tracked by the underlying
     /// <see cref="DbContext" />, this method will return the cached entity.
     /// </summary>
-    /// <remarks>For implementers: the default implementation won't work for composite primary keys.</remarks>
-    /// <param name="id">The identifier that</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
-    /// <returns>Task with the found entity, or -null- if not found.</returns>
     public override async Task<TEntity?> FindAsync(TIdentity id, CancellationToken cancellationToken = default)
     {
         return await FindTrackedOrLoadNewAsync(

--- a/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
@@ -60,7 +60,19 @@ public abstract class EFRepository<TEntity, TIdentity, TContext> : IRepository<T
         }
     }
 
-    public abstract Task<TEntity?> FindAsync(TIdentity id, CancellationToken cancellationToken = default);
+    protected virtual IQueryable<TEntity> BaseQuery() => DbSet.AsQueryable();
+
+    /// <summary>
+    /// Finds an entity by primary key.
+    /// </summary>
+    /// <remarks>For implementers: the default implementation won't work for composite primary keys.</remarks>
+    /// <param name="id">The identifier that</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>Task with the found entity, or -null- if not found.</returns>
+    public virtual async Task<TEntity?> FindAsync(TIdentity id, CancellationToken cancellationToken = default)
+    {
+        return await BaseQuery().AsTracking().FirstOrDefaultAsync(e => e.Id.Equals(id), cancellationToken);
+    }
 
     [SuppressMessage(
         "?",

--- a/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
@@ -1,10 +1,7 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using LeanCode.DomainModels.DataAccess;
 using LeanCode.DomainModels.Model;
 using LeanCode.TimeProvider;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
 
 namespace LeanCode.DomainModels.EF;
 
@@ -72,41 +69,5 @@ public abstract class EFRepository<TEntity, TIdentity, TContext> : IRepository<T
     public virtual async Task<TEntity?> FindAsync(TIdentity id, CancellationToken cancellationToken = default)
     {
         return await BaseQuery().AsTracking().FirstOrDefaultAsync(e => e.Id.Equals(id), cancellationToken);
-    }
-
-    [SuppressMessage(
-        "?",
-        "EF1001",
-        Justification = "This is basically the `EntityFinder.FindTracked` to mimic `FindAsync` snapshot re-use."
-    )]
-    protected TEntity? FindTracked(TIdentity id)
-    {
-        // Safety: aggregates are bound to have Id as a primary key by design.
-        var primaryKey = DbContext.Model.FindEntityType(typeof(TEntity))!.FindPrimaryKey()!;
-        return ((IDbContextDependencies)DbContext).StateManager!.TryGetEntryTyped(primaryKey, id)?.Entity as TEntity;
-    }
-
-    [SuppressMessage(
-        "?",
-        "EF1001",
-        Justification = "This is basically the `EntityFinder.FindTracked` to mimic `FindAsync` snapshot re-use."
-    )]
-    protected TEntity? FindTracked(params object[] id)
-    {
-        // Safety: aggregates are bound to have Id as a primary key by design.
-        var primaryKey = DbContext.Model.FindEntityType(typeof(TEntity))!.FindPrimaryKey()!;
-        return ((IDbContextDependencies)DbContext).StateManager!.TryGetEntryTyped(primaryKey, id)?.Entity as TEntity;
-    }
-
-    protected ValueTask<TEntity?> FindTrackedOrLoadNewAsync(TIdentity id, Func<DbSet<TEntity>, Task<TEntity?>> query)
-    {
-        var tracked = FindTracked(id);
-        return tracked is not null ? new(tracked) : new(query(DbSet));
-    }
-
-    protected ValueTask<TEntity?> FindTrackedOrLoadNewAsync(object[] id, Func<DbSet<TEntity>, Task<TEntity?>> query)
-    {
-        var tracked = FindTracked(id);
-        return tracked is not null ? new(tracked) : new(query(DbSet));
     }
 }

--- a/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/EFRepository.cs
@@ -63,7 +63,7 @@ public abstract class EFRepository<TEntity, TIdentity, TContext> : IRepository<T
     /// Finds an entity by primary key.
     /// </summary>
     /// <remarks>For implementers: the default implementation won't work for composite primary keys.</remarks>
-    /// <param name="id">The identifier that</param>
+    /// <param name="id">The identifier of the aggregate.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
     /// <returns>Task with the found entity, or -null- if not found.</returns>
     public virtual async Task<TEntity?> FindAsync(TIdentity id, CancellationToken cancellationToken = default)

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingCompositeTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingCompositeTests.cs
@@ -172,7 +172,7 @@ public class EFRepositoryTrackingCompositeTests
         }
     }
 
-    private sealed class EntityRepository : EFRepository<Entity, (int, int), TestDbContext>
+    private sealed class EntityRepository : CachingEFRepository<Entity, (int, int), TestDbContext>
     {
         public EntityRepository(TestDbContext dbContext)
             : base(dbContext) { }

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingCompositeTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingCompositeTests.cs
@@ -9,8 +9,8 @@ namespace LeanCode.DomainModels.EF.Tests;
 
 public class EFRepositoryTrackingCompositeTests
 {
-    private readonly InMemoryDatabaseRoot DbRoot = new();
-    private readonly Guid DbId = Guid.NewGuid();
+    private readonly InMemoryDatabaseRoot dbRoot = new();
+    private readonly Guid dbId = Guid.NewGuid();
 
     [Fact]
     public void Does_not_return_tracked_entity_if_it_is_not_there()
@@ -143,7 +143,7 @@ public class EFRepositoryTrackingCompositeTests
 
     private (TestDbContext, EntityRepository) Prepare()
     {
-        var context = TestDbContext.Create(DbRoot, DbId);
+        var context = TestDbContext.Create(dbRoot, dbId);
         context.Database.EnsureCreated();
         return (context, new(context));
     }

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingTests.cs
@@ -9,8 +9,8 @@ namespace LeanCode.DomainModels.EF.Tests;
 
 public class EFRepositoryTrackingTests
 {
-    private readonly InMemoryDatabaseRoot DbRoot = new();
-    private readonly Guid DbId = Guid.NewGuid();
+    private readonly InMemoryDatabaseRoot dbRoot = new();
+    private readonly Guid dbId = Guid.NewGuid();
 
     [Fact]
     public void Does_not_return_tracked_entity_if_it_is_not_there()
@@ -143,7 +143,7 @@ public class EFRepositoryTrackingTests
 
     private (TestDbContext, EntityRepository) Prepare()
     {
-        var context = TestDbContext.Create(DbRoot, DbId);
+        var context = TestDbContext.Create(dbRoot, dbId);
         context.Database.EnsureCreated();
         return (context, new(context));
     }

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingTests.cs
@@ -1,0 +1,190 @@
+#nullable enable
+using FluentAssertions;
+using LeanCode.DomainModels.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
+
+namespace LeanCode.DomainModels.EF.Tests;
+
+public class EFRepositoryTrackingTests
+{
+    private readonly InMemoryDatabaseRoot DbRoot = new();
+    private readonly Guid DbId = Guid.NewGuid();
+
+    [Fact]
+    public void Does_not_return_tracked_entity_if_it_is_not_there()
+    {
+        var (_, repository) = Prepare();
+
+        repository.FindTracked(0).Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_tracked_entity_if_it_is_not_in_the_database_but_has_been_added_to_the_tracker()
+    {
+        var (_, repository) = Prepare();
+        var entity = new Entity(10);
+
+        repository.Add(entity);
+
+        repository.FindTracked(entity.Id).Should().Be(entity);
+    }
+
+    [Fact]
+    public void Does_not_return_entity_if_it_has_been_tracked_in_different_context()
+    {
+        var (_, repository1) = Prepare();
+        var (_, repository2) = Prepare();
+        var entity = new Entity(10);
+
+        repository1.Add(entity);
+
+        repository2.FindTracked(entity.Id).Should().BeNull();
+    }
+
+    [Fact]
+    public void Does_not_return_entity_if_it_is_in_database_but_has_not_been_tracked_yet()
+    {
+        var entity = new Entity(10);
+        SaveEntity(entity);
+
+        var (_, repository) = Prepare();
+        repository.FindTracked(entity.Id).Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_entity_if_it_was_tracked_already()
+    {
+        var entity = new Entity(10);
+        SaveEntity(entity);
+
+        var (ctx, repository) = Prepare();
+        ctx.Entities.Find(entity.Id); // Load the entity
+
+        repository.FindTracked(entity.Id).Should().BeEquivalentTo(entity);
+        repository.FindTracked(entity.Id).Should().NotBeSameAs(entity);
+    }
+
+    [Fact]
+    public void If_the_entity_is_tracked_but_gets_deleted_from_the_underlying_database_It_is_still_returned()
+    {
+        var entity = new Entity(10);
+        SaveEntity(entity);
+
+        var (ctx, repository) = Prepare();
+        ctx.Entities.Find(entity.Id); // Load the entity
+
+        DeleteEntity(entity);
+
+        repository.FindTracked(entity.Id).Should().BeEquivalentTo(entity);
+        repository.FindTracked(entity.Id).Should().NotBeSameAs(entity);
+    }
+
+    [Fact]
+    public async Task Loading_the_entity_tracks_it_and_then_returns_tracked_entity_in_the_consecutive_calls()
+    {
+        var entity = new Entity(10);
+        SaveEntity(entity);
+
+        var (_, repository) = Prepare();
+
+        var existing1 = await repository.FindAsync(entity.Id);
+        var existing2 = await repository.FindAsync(entity.Id);
+
+        existing1.Should().BeEquivalentTo(entity);
+        existing2.Should().Be(existing1);
+    }
+
+    [Fact]
+    public async Task If_the_entity_is_loaded_It_stays_tracked_even_if_it_gets_deleted_from_the_database()
+    {
+        var entity = new Entity(10);
+        SaveEntity(entity);
+
+        var (_, repository) = Prepare();
+
+        var existing1 = await repository.FindAsync(entity.Id);
+        DeleteEntity(entity);
+
+        var existing2 = await repository.FindAsync(entity.Id);
+
+        existing1.Should().BeEquivalentTo(entity);
+        existing2.Should().Be(existing1);
+    }
+
+    [Fact]
+    public void If_the_entity_is_loaded_from_database_in_different_context_It_is_not_tracked_in_another()
+    {
+        var entity = new Entity(10);
+        SaveEntity(entity);
+
+        var (ctx, _) = Prepare();
+        ctx.Entities.Find(entity.Id); // Load the entity
+
+        var (_, anotherRepository) = Prepare();
+        anotherRepository.FindTracked(entity.Id).Should().BeNull();
+    }
+
+    private void SaveEntity(Entity entity)
+    {
+        var (ctx1, repository1) = Prepare();
+        repository1.Add(entity);
+        ctx1.SaveChanges();
+    }
+
+    private void DeleteEntity(Entity entity)
+    {
+        var (ctx1, repository1) = Prepare();
+        var existing = ctx1.Entities.First(e => e.Id == entity.Id);
+        ctx1.Entities.Remove(existing);
+        ctx1.SaveChanges();
+    }
+
+    private (TestDbContext, TestRepository) Prepare()
+    {
+        var context = TestDbContext.Create(DbRoot, DbId);
+        context.Database.EnsureCreated();
+        return (context, new(context));
+    }
+
+    private sealed class TestDbContext : DbContext
+    {
+        public DbSet<Entity> Entities => Set<Entity>();
+
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options) { }
+
+        public static TestDbContext Create(InMemoryDatabaseRoot root, Guid dbId)
+        {
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase($"TestDb{dbId:N}", root)
+                .Options;
+            return new(options);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Entity>(cfg =>
+            {
+                cfg.HasKey(e => e.Id);
+            });
+        }
+    }
+
+    private sealed class TestRepository : EFRepository<Entity, int, TestDbContext>
+    {
+        public TestRepository(TestDbContext dbContext)
+            : base(dbContext) { }
+
+        public new Entity? FindTracked(int id)
+        {
+            return base.FindTracked(id);
+        }
+
+        public override Task<Entity?> FindAsync(int id, CancellationToken cancellationToken = default) =>
+            FindTrackedOrLoadNewAsync(id, DbSet.AsQueryable(), cancellationToken).AsTask();
+    }
+
+    private sealed record Entity(int Id) : IAggregateRootWithoutOptimisticConcurrency<int>;
+}

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/EFRepositoryTrackingTests.cs
@@ -172,7 +172,7 @@ public class EFRepositoryTrackingTests
         }
     }
 
-    private sealed class EntityRepository : EFRepository<Entity, int, TestDbContext>
+    private sealed class EntityRepository : CachingEFRepository<Entity, int, TestDbContext>
     {
         public EntityRepository(TestDbContext dbContext)
             : base(dbContext) { }

--- a/test/LeanCode.IntegrationTests/App/Entity.cs
+++ b/test/LeanCode.IntegrationTests/App/Entity.cs
@@ -4,7 +4,7 @@ using LeanCode.TimeProvider;
 
 namespace LeanCode.IntegrationTests.App;
 
-public class Entity
+public class Entity : IAggregateRootWithoutOptimisticConcurrency<Guid>
 {
     public Guid Id { get; set; }
     public string Value { get; set; } = null!;

--- a/test/LeanCode.IntegrationTests/CQRSTests.cs
+++ b/test/LeanCode.IntegrationTests/CQRSTests.cs
@@ -8,11 +8,11 @@ using Xunit;
 namespace LeanCode.IntegrationTests;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("?", "CA1001", Justification = "Disposed with `IAsyncLifetime`.")]
-public class Tests : IAsyncLifetime
+public class CQRSTests : IAsyncLifetime
 {
     private readonly TestApp app;
 
-    public Tests()
+    public CQRSTests()
     {
         app = new TestApp();
     }

--- a/test/LeanCode.IntegrationTests/EFRepositoryTests.cs
+++ b/test/LeanCode.IntegrationTests/EFRepositoryTests.cs
@@ -14,7 +14,7 @@ public class EFRepositoryTests : IAsyncLifetime
     [Fact]
     public async Task Default_implementation_of_EFRepository_works()
     {
-        var entity = new Entity { Id = Guid.NewGuid() };
+        var entity = new Entity { Id = Guid.NewGuid(), Value = "test value" };
 
         await EnsureEntityDoesNotExistAsync(entity);
         await AddEntityAsync(entity);

--- a/test/LeanCode.IntegrationTests/EFRepositoryTests.cs
+++ b/test/LeanCode.IntegrationTests/EFRepositoryTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using LeanCode.DomainModels.EF;
+using LeanCode.IntegrationTests.App;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace LeanCode.IntegrationTests;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("?", "CA1001", Justification = "Disposed with `IAsyncLifetime`.")]
+public class EFRepositoryTests : IAsyncLifetime
+{
+    private readonly TestApp app = new();
+
+    [Fact]
+    public async Task Default_implementation_of_EFRepository_works()
+    {
+        var entity = new Entity { Id = Guid.NewGuid() };
+
+        await EnsureEntityDoesNotExistAsync(entity);
+        await AddEntityAsync(entity);
+        await EnsureEntityIsFoundAsync(entity);
+    }
+
+    private async Task EnsureEntityIsFoundAsync(Entity entity)
+    {
+        await using var scope = app.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        var repository = new EntityRepository(dbContext);
+
+        var foundEntity = await repository.FindAsync(entity.Id);
+        foundEntity.Should().BeEquivalentTo(entity);
+    }
+
+    private async Task AddEntityAsync(Entity entity)
+    {
+        await using var scope = app.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        var repository = new EntityRepository(dbContext);
+        repository.Add(entity);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private async Task EnsureEntityDoesNotExistAsync(Entity entity)
+    {
+        await using var scope = app.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        var repository = new EntityRepository(dbContext);
+
+        var foundEntity = await repository.FindAsync(entity.Id);
+        foundEntity.Should().BeNull();
+    }
+
+    public Task InitializeAsync() => app.InitializeAsync();
+
+    public Task DisposeAsync() => app.DisposeAsync().AsTask();
+
+    class EntityRepository : EFRepository<Entity, Guid, TestDbContext>
+    {
+        public EntityRepository(TestDbContext dbContext)
+            : base(dbContext) { }
+    }
+}

--- a/test/LeanCode.IntegrationTests/EFRepositoryTests.cs
+++ b/test/LeanCode.IntegrationTests/EFRepositoryTests.cs
@@ -54,7 +54,7 @@ public class EFRepositoryTests : IAsyncLifetime
 
     public Task DisposeAsync() => app.DisposeAsync().AsTask();
 
-    class EntityRepository : EFRepository<Entity, Guid, TestDbContext>
+    private sealed class EntityRepository : EFRepository<Entity, Guid, TestDbContext>
     {
         public EntityRepository(TestDbContext dbContext)
             : base(dbContext) { }


### PR DESCRIPTION
This adds two helper methods that try to streamline loading already-tracked entities in repositories. They basically try to replicate how [`FindAsync`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbset-1.findasync?view=efcore-7.0) works, but to also allow to use `Include`s.

It is very important that the `Include`s used in all calls stay the same (otherwise, you might get entity that looks different by mistake), that's why they are constrained to `EFRepository` - we already have this assumption there (i.e. we should load the whole aggregate, always).

Since this almost abuses EF internals, there is a lot of test for 4 lines of code. :)

Closes COR-121