### PR TITLE
Allow defining authorizers using only `ClaimsPrincipal`s

### DIFF
--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
@@ -24,7 +24,7 @@ public class CQRSSecurityMiddleware
         var customAuthorizers = AuthorizeWhenAttribute.GetCustomAuthorizers(cqrsMetadata.ObjectType);
         var user = context.User;
 
-        if (customAuthorizers.Count > 0 && !(user?.Identity?.IsAuthenticated ?? false))
+        if (customAuthorizers.Count > 0 && !(user.Identity?.IsAuthenticated ?? false))
         {
             logger.Warning("The current user is not authenticated and the object requires authorization");
 
@@ -35,7 +35,7 @@ public class CQRSSecurityMiddleware
         foreach (var customAuthorizerDefinition in customAuthorizers)
         {
             var authorizerType = customAuthorizerDefinition.Authorizer;
-            var customAuthorizer = context.RequestServices.GetService(authorizerType) as ICustomAuthorizer;
+            var customAuthorizer = context.RequestServices.GetService(authorizerType) as IHttpContextCustomAuthorizer;
 
             if (customAuthorizer is null)
             {
@@ -43,7 +43,7 @@ public class CQRSSecurityMiddleware
             }
 
             var authorized = await customAuthorizer.CheckIfAuthorizedAsync(
-                user,
+                context,
                 payload.Payload,
                 customAuthorizerDefinition.CustomData
             );

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
@@ -43,7 +43,7 @@ public class CQRSSecurityMiddleware
             }
 
             var authorized = await customAuthorizer.CheckIfAuthorizedAsync(
-                context,
+                user,
                 payload.Payload,
                 customAuthorizerDefinition.CustomData
             );

--- a/src/CQRS/LeanCode.CQRS.Security/CustomAuthorizer.cs
+++ b/src/CQRS/LeanCode.CQRS.Security/CustomAuthorizer.cs
@@ -19,7 +19,7 @@ public interface ICustomAuthorizer : IHttpContextCustomAuthorizer
     ) => CheckIfAuthorizedAsync(context.User, obj, customData);
 }
 
-public abstract class CustomHttpContextAuthorizer<TObject> : IHttpContextCustomAuthorizer
+public abstract class HttpContextCustomAuthorizer<TObject> : IHttpContextCustomAuthorizer
 {
     public Task<bool> CheckIfAuthorizedAsync(HttpContext context, object obj, object? customData) =>
         CheckIfAuthorizedAsync(context, (TObject)obj);
@@ -35,7 +35,7 @@ public abstract class CustomAuthorizer<TObject> : ICustomAuthorizer
     protected abstract Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, TObject obj);
 }
 
-public abstract class CustomHttpContextAuthorizer<TObject, TCustomData> : IHttpContextCustomAuthorizer
+public abstract class HttpContextCustomAuthorizer<TObject, TCustomData> : IHttpContextCustomAuthorizer
 {
     public Task<bool> CheckIfAuthorizedAsync(HttpContext context, object obj, object? customData) =>
         CheckIfAuthorizedInternalAsync(context, (TObject)obj, customData);

--- a/src/CQRS/LeanCode.CQRS.Security/CustomAuthorizer.cs
+++ b/src/CQRS/LeanCode.CQRS.Security/CustomAuthorizer.cs
@@ -1,29 +1,30 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 
 namespace LeanCode.CQRS.Security;
 
 public interface ICustomAuthorizer
 {
-    Task<bool> CheckIfAuthorizedAsync(HttpContext httpContext, object obj, object? customData);
+    Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, object obj, object? customData);
 }
 
 public abstract class CustomAuthorizer<TObject> : ICustomAuthorizer
 {
-    public Task<bool> CheckIfAuthorizedAsync(HttpContext httpContext, object obj, object? customData) =>
-        CheckIfAuthorizedAsync(httpContext, (TObject)obj);
+    public Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, object obj, object? customData) =>
+        CheckIfAuthorizedAsync(user, (TObject)obj);
 
-    protected abstract Task<bool> CheckIfAuthorizedAsync(HttpContext httpContext, TObject obj);
+    protected abstract Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, TObject obj);
 }
 
 public abstract class CustomAuthorizer<TObject, TCustomData> : ICustomAuthorizer
     where TCustomData : class
 {
-    public Task<bool> CheckIfAuthorizedAsync(HttpContext httpContext, object obj, object? customData) =>
-        CheckIfAuthorizedInternalAsync(httpContext, (TObject)obj, customData);
+    public Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, object obj, object? customData) =>
+        CheckIfAuthorizedInternalAsync(user, (TObject)obj, customData);
 
-    protected abstract Task<bool> CheckIfAuthorizedAsync(HttpContext httpContext, TObject obj, TCustomData? customData);
+    protected abstract Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, TObject obj, TCustomData? customData);
 
-    private Task<bool> CheckIfAuthorizedInternalAsync(HttpContext httpContext, TObject obj, object? customData)
+    private Task<bool> CheckIfAuthorizedInternalAsync(ClaimsPrincipal user, TObject obj, object? customData)
     {
         if (!(customData is null || customData is TCustomData))
         {
@@ -33,6 +34,6 @@ public abstract class CustomAuthorizer<TObject, TCustomData> : ICustomAuthorizer
             );
         }
 
-        return CheckIfAuthorizedAsync(httpContext, obj, (TCustomData?)customData);
+        return CheckIfAuthorizedAsync(user, obj, (TCustomData?)customData);
     }
 }

--- a/src/CQRS/LeanCode.CQRS.Security/CustomAuthorizer.cs
+++ b/src/CQRS/LeanCode.CQRS.Security/CustomAuthorizer.cs
@@ -40,7 +40,7 @@ public abstract class HttpContextCustomAuthorizer<TObject, TCustomData> : IHttpC
     public Task<bool> CheckIfAuthorizedAsync(HttpContext context, object obj, object? customData) =>
         CheckIfAuthorizedInternalAsync(context, (TObject)obj, customData);
 
-    protected abstract Task<bool> CheckIfAuthorizedAsync(HttpContext context, TObject obj);
+    protected abstract Task<bool> CheckIfAuthorizedAsync(HttpContext context, TObject obj, TCustomData? customData);
 
     private Task<bool> CheckIfAuthorizedInternalAsync(HttpContext context, TObject obj, object? customData)
     {

--- a/src/CQRS/LeanCode.CQRS.Security/DefaultPermissionAuthorizer.cs
+++ b/src/CQRS/LeanCode.CQRS.Security/DefaultPermissionAuthorizer.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using System.Threading.Tasks;
 using LeanCode.Contracts.Security;
 using Microsoft.AspNetCore.Http;
@@ -15,9 +16,9 @@ public class DefaultPermissionAuthorizer : CustomAuthorizer<object, string[]>, I
         this.registry = registry;
     }
 
-    protected override Task<bool> CheckIfAuthorizedAsync(HttpContext httpContext, object obj, string[]? customData)
+    protected override Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, object obj, string[]? customData)
     {
-        if (!httpContext.User.HasPermission(registry, customData ?? Array.Empty<string>()))
+        if (!user.HasPermission(registry, customData ?? Array.Empty<string>()))
         {
             logger.Warning(
                 "User does not have sufficient permissions ({Permissions}) to run {@Object}",

--- a/src/CQRS/LeanCode.CQRS.Security/IAuthorizerResolver.cs
+++ b/src/CQRS/LeanCode.CQRS.Security/IAuthorizerResolver.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-
 namespace LeanCode.CQRS.Security;
 
 public interface IAuthorizerResolver<TAppContext>

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/CustomAuthorizer.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/CustomAuthorizer.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
 using LeanCode.Contracts.Security;
 using LeanCode.CQRS.Security;
 using Microsoft.AspNetCore.Http;
@@ -15,7 +16,7 @@ public interface ICustomAuthorizer { }
 
 public class CustomAuthorizer : CustomAuthorizer<ICustomAuthorizerParams>, ICustomAuthorizer
 {
-    protected override Task<bool> CheckIfAuthorizedAsync(HttpContext httpContext, ICustomAuthorizerParams obj)
+    protected override Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, ICustomAuthorizerParams obj)
     {
         return Task.FromResult(!obj.FailAuthorization);
     }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/CustomAuthorizer.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/CustomAuthorizer.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using LeanCode.Contracts.Security;
 using LeanCode.CQRS.Security;
-using Microsoft.AspNetCore.Http;
 
 namespace LeanCode.CQRS.AspNetCore.Tests.Integration;
 

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/HttpContextCustomAuthorizer.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/HttpContextCustomAuthorizer.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.CodeAnalysis;
+using LeanCode.Contracts.Security;
+using LeanCode.CQRS.Security;
+using Microsoft.AspNetCore.Http;
+
+namespace LeanCode.CQRS.AspNetCore.Tests.Integration;
+
+public interface IHttpContextCustomAuthorizerParams
+{
+    public bool FailAuthorization { get; set; }
+}
+
+[SuppressMessage("?", "CA1040", Justification = "Marker interface")]
+public interface IHttpContextCustomAuthorizer { }
+
+public class HttpContextCustomAuthorizer
+    : HttpContextCustomAuthorizer<IHttpContextCustomAuthorizerParams>,
+        IHttpContextCustomAuthorizer
+{
+    protected override Task<bool> CheckIfAuthorizedAsync(HttpContext context, IHttpContextCustomAuthorizerParams obj)
+    {
+        return Task.FromResult(!obj.FailAuthorization);
+    }
+}
+
+public sealed class HttpContextCustomAuthorizeWhenAttribute : AuthorizeWhenAttribute
+{
+    public HttpContextCustomAuthorizeWhenAttribute()
+        : base(typeof(IHttpContextCustomAuthorizer)) { }
+}

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/RemoteCQRSTestsBase.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/RemoteCQRSTestsBase.cs
@@ -30,6 +30,7 @@ public abstract class RemoteCQRSTestsBase : IDisposable, IAsyncLifetime
                     .ConfigureServices(cfg =>
                     {
                         cfg.AddScoped<ICustomAuthorizer, CustomAuthorizer>();
+                        cfg.AddScoped<IHttpContextCustomAuthorizer, HttpContextCustomAuthorizer>();
                         cfg.AddRouting();
                         cfg.AddCQRS(TypesCatalog.Of<TestCommand>(), TypesCatalog.Of<TestCommandHandler>());
                         cfg.AddFluentValidation(TypesCatalog.Of<TestCommandValidator>());

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/TestOperation.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/TestOperation.cs
@@ -4,8 +4,8 @@ using Microsoft.AspNetCore.Http;
 
 namespace LeanCode.CQRS.AspNetCore.Tests.Integration;
 
-[CustomAuthorizeWhen]
-public class TestOperation : IOperation<TestOperationResult>, ICustomAuthorizerParams
+[HttpContextCustomAuthorizeWhen]
+public class TestOperation : IOperation<TestOperationResult>, IHttpContextCustomAuthorizerParams
 {
     public bool FailAuthorization { get; set; }
 

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
@@ -120,7 +120,7 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
 
         await firstAuthorizer
             .Received()
-            .CheckIfAuthorizedAsync(Arg.Any<HttpContext>(), cmd, SingleAuthorizerCustomData);
+            .CheckIfAuthorizedAsync(Arg.Any<ClaimsPrincipal>(), cmd, SingleAuthorizerCustomData);
     }
 
     private Task<HttpContext> SendPayloadAsync(object payload, ClaimsPrincipal? user = null)

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
@@ -26,14 +26,14 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
     private readonly TestServer server;
 
     private readonly ICustomAuthorizer firstAuthorizer;
-    private readonly ICustomAuthorizer secondAuthorizer;
+    private readonly IHttpContextCustomAuthorizer secondAuthorizer;
 
     private static ClaimsPrincipal AuthenticatedUser() => new(new ClaimsIdentity("TEST"));
 
     public CQRSSecurityMiddlewareTests()
     {
         firstAuthorizer = Substitute.For<ICustomAuthorizer, IFirstAuthorizer>();
-        secondAuthorizer = Substitute.For<ICustomAuthorizer, ISecondAuthorizer>();
+        secondAuthorizer = Substitute.For<IHttpContextCustomAuthorizer, ISecondAuthorizer>();
 
         host = new HostBuilder()
             .ConfigureWebHost(webHost =>
@@ -120,7 +120,7 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
 
         await firstAuthorizer
             .Received()
-            .CheckIfAuthorizedAsync(Arg.Any<ClaimsPrincipal>(), cmd, SingleAuthorizerCustomData);
+            .CheckIfAuthorizedAsync(Arg.Any<HttpContext>(), cmd, SingleAuthorizerCustomData);
     }
 
     private Task<HttpContext> SendPayloadAsync(object payload, ClaimsPrincipal? user = null)
@@ -153,7 +153,7 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
         Assert.Equal(statusCode, result!.Value.StatusCode);
     }
 
-    private static void SetAuthorizationResultAsync(ICustomAuthorizer authorizer, bool result)
+    private static void SetAuthorizationResultAsync(IHttpContextCustomAuthorizer authorizer, bool result)
     {
         authorizer.CheckIfAuthorizedAsync(null!, null!, null).ReturnsForAnyArgs(result);
     }

--- a/test/CQRS/LeanCode.CQRS.Security.Tests/CustomAuthorizerTests.cs
+++ b/test/CQRS/LeanCode.CQRS.Security.Tests/CustomAuthorizerTests.cs
@@ -1,0 +1,131 @@
+using System.Security.Claims;
+using FluentAssertions;
+using LeanCode.CQRS.Security;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Xunit;
+
+namespace LeanCode.CQRS.Default.Tests.Security;
+
+public class CustomAuthorizerTests
+{
+    private readonly AClass aClass = new() { AProperty = "Hello" };
+    private readonly AnotherClass anotherClass = new() { AnotherProperty = "World" };
+
+    [Fact]
+    public async Task CustomAuthorizerTObjectTCustomData_casts_data_properly_as_ICustomAuthorizer()
+    {
+        var customAuthorizer = new CustomAuthorizer();
+
+        await customAuthorizer
+            .Awaiting(c => c.CheckIfAuthorizedAsync(default!, new object(), new object()))
+            .Should()
+            .ThrowAsync<InvalidCastException>();
+
+        customAuthorizer.InternalWasCalled.Should().BeFalse();
+
+        await customAuthorizer
+            .Awaiting(c => c.CheckIfAuthorizedAsync(default!, aClass, new object()))
+            .Should()
+            .ThrowAsync<ArgumentException>();
+
+        customAuthorizer.InternalWasCalled.Should().BeFalse();
+
+        await customAuthorizer
+            .Awaiting(c => c.CheckIfAuthorizedAsync(default!, aClass, anotherClass))
+            .Should()
+            .NotThrowAsync();
+
+        customAuthorizer.InternalWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CustomAuthorizerTObjectTCustomData_casts_data_properly_as_IHttpContextCustomAuthorizer()
+    {
+        var httpContext = Substitute.For<HttpContext>();
+
+        var customAuthorizer = new CustomAuthorizer();
+
+        await customAuthorizer
+            .Awaiting(
+                c => ((IHttpContextCustomAuthorizer)c).CheckIfAuthorizedAsync(httpContext, new object(), new object())
+            )
+            .Should()
+            .ThrowAsync<InvalidCastException>();
+
+        customAuthorizer.InternalWasCalled.Should().BeFalse();
+
+        await customAuthorizer
+            .Awaiting(c => ((IHttpContextCustomAuthorizer)c).CheckIfAuthorizedAsync(httpContext, aClass, new object()))
+            .Should()
+            .ThrowAsync<ArgumentException>();
+
+        customAuthorizer.InternalWasCalled.Should().BeFalse();
+
+        await customAuthorizer
+            .Awaiting(c => ((IHttpContextCustomAuthorizer)c).CheckIfAuthorizedAsync(httpContext, aClass, anotherClass))
+            .Should()
+            .NotThrowAsync();
+
+        customAuthorizer.InternalWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HttpContextCustomAuthorizerTObjectTCustomData_casts_data_properly_as_IHttpContextCustomAuthorizer()
+    {
+        var customAuthorizer = new HttpContextCustomAuthorizer();
+
+        await customAuthorizer
+            .Awaiting(c => c.CheckIfAuthorizedAsync(default!, new object(), new object()))
+            .Should()
+            .ThrowAsync<InvalidCastException>();
+
+        customAuthorizer.InternalWasCalled.Should().BeFalse();
+
+        await customAuthorizer
+            .Awaiting(c => ((IHttpContextCustomAuthorizer)c).CheckIfAuthorizedAsync(default!, aClass, new object()))
+            .Should()
+            .ThrowAsync<ArgumentException>();
+
+        customAuthorizer.InternalWasCalled.Should().BeFalse();
+
+        await customAuthorizer
+            .Awaiting(c => ((IHttpContextCustomAuthorizer)c).CheckIfAuthorizedAsync(default!, aClass, anotherClass))
+            .Should()
+            .NotThrowAsync();
+
+        customAuthorizer.InternalWasCalled.Should().BeTrue();
+    }
+
+    private class HttpContextCustomAuthorizer : HttpContextCustomAuthorizer<AClass, AnotherClass>
+    {
+        protected override Task<bool> CheckIfAuthorizedAsync(HttpContext context, AClass obj, AnotherClass customData)
+        {
+            InternalWasCalled = true;
+            return Task.FromResult(true);
+        }
+
+        public bool InternalWasCalled { get; private set; }
+    }
+
+    private class CustomAuthorizer : CustomAuthorizer<AClass, AnotherClass>
+    {
+        protected override Task<bool> CheckIfAuthorizedAsync(ClaimsPrincipal user, AClass obj, AnotherClass customData)
+        {
+            InternalWasCalled = true;
+            return Task.FromResult(true);
+        }
+
+        public bool InternalWasCalled { get; private set; }
+    }
+
+    private class AClass
+    {
+        public string AProperty { get; set; }
+    }
+
+    private class AnotherClass
+    {
+        public string AnotherProperty { get; set; }
+    }
+}


### PR DESCRIPTION
They aren't in many cases limiting, yet they'll allow to be used in all kinds of topics in LeanPipe. Using authorizers basing on `HttpContext` is still possible.