### PR TITLE
Add LeanCode.ConfigCat package

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -51,6 +51,8 @@
 
     <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.1" />
 
+    <PackageReference Update="ConfigCat.Client" Version="8.2.0" />
+
     <PackageReference Update="Ory.Kratos.Client" Version="0.13.1" />
 
     <PackageReference Update="Cronos" Version="0.7.1" />

--- a/LeanCode.CoreLibrary.sln
+++ b/LeanCode.CoreLibrary.sln
@@ -189,6 +189,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeanCode.CQRS.Annotations",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeanCode.TimeProvider.TestHelpers", "src\Testing\LeanCode.TimeProvider.TestHelpers\LeanCode.TimeProvider.TestHelpers.csproj", "{9837D365-5F3B-4849-853A-F3ED506950D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LeanCode.ConfigCat", "src\Infrastructure\LeanCode.ConfigCat\LeanCode.ConfigCat.csproj", "{F69CBF02-F99A-44F5-8CBB-5F145187473E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1135,6 +1137,18 @@ Global
 		{9837D365-5F3B-4849-853A-F3ED506950D2}.Release|x64.Build.0 = Release|Any CPU
 		{9837D365-5F3B-4849-853A-F3ED506950D2}.Release|x86.ActiveCfg = Release|Any CPU
 		{9837D365-5F3B-4849-853A-F3ED506950D2}.Release|x86.Build.0 = Release|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Debug|x64.Build.0 = Debug|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Debug|x86.Build.0 = Debug|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Release|x64.ActiveCfg = Release|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Release|x64.Build.0 = Release|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Release|x86.ActiveCfg = Release|Any CPU
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1242,5 +1256,6 @@ Global
 		{78E74391-5455-41B5-AC59-1C07A06DB56E} = {D9CFC5C4-8B87-4EDF-85D1-1471EA1B6D27}
 		{3BD3AF48-38EC-4CD6-8BED-3996737C9128} = {54A36A22-89A6-4525-AB2D-FBBB643C0CE0}
 		{9837D365-5F3B-4849-853A-F3ED506950D2} = {DD0E6BF3-F966-426F-901A-D0140B7FE13C}
+		{F69CBF02-F99A-44F5-8CBB-5F145187473E} = {1358A1B6-E8BB-4607-8B61-FDAE49F0EAA4}
 	EndGlobalSection
 EndGlobal

--- a/src/Infrastructure/LeanCode.ConfigCat/ConfigCatExtensions.cs
+++ b/src/Infrastructure/LeanCode.ConfigCat/ConfigCatExtensions.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using ConfigCat.Client;
+using LeanCode.ConfigCat;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "?",
+    "IDE0130:NamespaceDoesNotMatchFolderStructure",
+    Justification = "Extensions on IServiceCollection by convention live in Microsoft.Extensions.DependencyInjection namespace.",
+    Scope = "namespace",
+    Target = "~N:Microsoft.Extensions.DependencyInjection"
+)]
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ConfigCatExtensions
+{
+    public static IServiceCollection AddConfigCat(
+        this IServiceCollection services,
+        string? sdkKey,
+        string? flagOverridesFilePath,
+        bool autoReload = true,
+        OverrideBehaviour overrideBehaviour = OverrideBehaviour.LocalOnly,
+        bool initializeOnStartup = false
+    )
+    {
+        return services.AddConfigCat(
+            sdkKey,
+            flagOverridesFilePath is null
+                ? null
+                : FlagOverrides.LocalFile(flagOverridesFilePath, autoReload, overrideBehaviour),
+            initializeOnStartup
+        );
+    }
+
+    public static IServiceCollection AddConfigCat(
+        this IServiceCollection services,
+        string? sdkKey,
+        IDictionary<string, object>? flagOverrides,
+        bool watchChanges = false,
+        OverrideBehaviour overrideBehaviour = OverrideBehaviour.LocalOnly,
+        bool initializeOnStartup = false
+    )
+    {
+        return services.AddConfigCat(
+            sdkKey,
+            flagOverrides is null
+                ? null
+                : FlagOverrides.LocalDictionary(flagOverrides, watchChanges, overrideBehaviour),
+            initializeOnStartup
+        );
+    }
+
+    public static IServiceCollection AddConfigCat(
+        this IServiceCollection services,
+        string? sdkKey,
+        FlagOverrides? flagOverrides = null,
+        bool initializeOnStartup = false
+    )
+    {
+        if (sdkKey is not { Length: > 0 } && flagOverrides is null)
+        {
+            throw new InvalidOperationException("At least one feature flags configuration method is needed.");
+        }
+
+        services.TryAddSingleton(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<ConfigCatClient>>();
+
+            return ConfigCatClient.Get(
+                sdkKey ?? "localhost",
+                options =>
+                {
+                    options.Logger = new ConfigCatToMSLoggerAdapter(logger);
+                    options.FlagOverrides = flagOverrides;
+                    options.Offline =
+                        flagOverrides is not null && flagOverrides.OverrideBehaviour == OverrideBehaviour.LocalOnly;
+                }
+            );
+        });
+
+        return services.TryAddConfigCatInitializer(initializeOnStartup);
+    }
+
+    public static IServiceCollection AddConfigCat(this IServiceCollection services, bool initializeOnStartup = false)
+    {
+        services.TryAddSingleton(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<ConfigCatOptions>>().Value;
+
+            var flagOverrides = options switch
+            {
+                { FlagOverridesJsonObject: { } json }
+                    when JsonSerializer.Deserialize<IDictionary<string, object>>(json) is { } dictionary
+                    => FlagOverrides.LocalDictionary(dictionary, watchChanges: false, OverrideBehaviour.LocalOnly),
+                { FlagOverridesFilePath: { Length: > 0 } filePath }
+                    => FlagOverrides.LocalFile(filePath, autoReload: true, OverrideBehaviour.LocalOnly),
+                _ => null,
+            };
+
+            if (options.SdkKey is not { Length: > 0 } && flagOverrides is null)
+            {
+                throw new InvalidOperationException("At least one feature flags configuration method is needed.");
+            }
+
+            var logger = sp.GetRequiredService<ILogger<ConfigCatClient>>();
+
+            return ConfigCatClient.Get(
+                options.SdkKey ?? "localhost",
+                options =>
+                {
+                    options.Logger = new ConfigCatToMSLoggerAdapter(logger);
+                    options.FlagOverrides = flagOverrides;
+                    options.Offline = flagOverrides is not null;
+                }
+            );
+        });
+
+        return services.TryAddConfigCatInitializer(initializeOnStartup);
+    }
+
+    private static IServiceCollection TryAddConfigCatInitializer(this IServiceCollection services, bool add)
+    {
+        return add ? services.AddHostedService<ConfigCatInitializer>() : services;
+    }
+}

--- a/src/Infrastructure/LeanCode.ConfigCat/ConfigCatInitializer.cs
+++ b/src/Infrastructure/LeanCode.ConfigCat/ConfigCatInitializer.cs
@@ -1,0 +1,28 @@
+using ConfigCat.Client;
+using Microsoft.Extensions.Hosting;
+
+namespace LeanCode.ConfigCat;
+
+public sealed class ConfigCatInitializer : BackgroundService
+{
+    private readonly IConfigCatClient configCatClient;
+
+    public ConfigCatInitializer(IConfigCatClient configCatClient)
+    {
+        this.configCatClient = configCatClient;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "?",
+        "CA1031:DoNotCatchGeneralExceptionTypes",
+        Justification = "We don't want any exceptions to be propagated."
+    )]
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await configCatClient.GetAllKeysAsync(stoppingToken);
+        }
+        catch { }
+    }
+}

--- a/src/Infrastructure/LeanCode.ConfigCat/ConfigCatOptions.cs
+++ b/src/Infrastructure/LeanCode.ConfigCat/ConfigCatOptions.cs
@@ -1,0 +1,11 @@
+namespace LeanCode.ConfigCat;
+
+public sealed record class ConfigCatOptions(
+    string? SdkKey,
+    string? FlagOverridesFilePath,
+    string? FlagOverridesJsonObject
+)
+{
+    public ConfigCatOptions()
+        : this(default, default, default) { }
+};

--- a/src/Infrastructure/LeanCode.ConfigCat/ConfigCatToMSLoggerAdapter.cs
+++ b/src/Infrastructure/LeanCode.ConfigCat/ConfigCatToMSLoggerAdapter.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using ConfigCat.Client;
+using Microsoft.Extensions.Logging;
+using CCLogLevel = ConfigCat.Client.LogLevel;
+using MSLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace LeanCode.ConfigCat;
+
+// https://github.com/configcat/.net-sdk/blob/57f08f27508e6f98c6e4db5ca305dfa4ade36b0f/samples/ASP.NETCore/WebApplication/Adapters/ConfigCatToMSLoggerAdapter.cs
+public class ConfigCatToMSLoggerAdapter : IConfigCatLogger
+{
+    private readonly ILogger logger;
+
+    public ConfigCatToMSLoggerAdapter(ILogger<ConfigCatClient> logger)
+    {
+        this.logger = logger;
+    }
+
+    // Allow all log levels here and let MS logger do log level filtering (see appsettings.json)
+    public CCLogLevel LogLevel
+    {
+        get => CCLogLevel.Debug;
+        set { }
+    }
+
+    public void Log(
+        CCLogLevel level,
+        LogEventId eventId,
+        ref FormattableLogMessage message,
+        Exception? exception = null
+    )
+    {
+        var logLevel = level switch
+        {
+            CCLogLevel.Error => MSLogLevel.Error,
+            CCLogLevel.Warning => MSLogLevel.Warning,
+            CCLogLevel.Info => MSLogLevel.Information,
+            CCLogLevel.Debug => MSLogLevel.Debug,
+            _ => MSLogLevel.None
+        };
+
+        var logValues = new LogValues(ref message);
+
+        logger.Log(
+            logLevel,
+            eventId.Id,
+            state: logValues,
+            exception,
+            static (state, _) => state.Message.InvariantFormattedMessage
+        );
+
+        message = logValues.Message;
+    }
+
+    // Support for structured logging.
+    private sealed class LogValues : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        public LogValues(ref FormattableLogMessage message)
+        {
+            Message = message;
+        }
+
+        public FormattableLogMessage Message { get; private set; }
+
+        public KeyValuePair<string, object?> this[int index]
+        {
+            get
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
+                return index == Count - 1
+                    ? new KeyValuePair<string, object?>("{OriginalFormat}", Message.Format)
+                    : new KeyValuePair<string, object?>(Message.ArgNames![index], Message.ArgValues![index]);
+            }
+        }
+
+        public int Count => (Message.ArgNames?.Length ?? 0) + 1;
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            for (int i = 0, n = Count; i < n; i++)
+            {
+                yield return this[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override string ToString() => Message.InvariantFormattedMessage;
+    }
+}

--- a/src/Infrastructure/LeanCode.ConfigCat/LeanCode.ConfigCat.csproj
+++ b/src/Infrastructure/LeanCode.ConfigCat/LeanCode.ConfigCat.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="ConfigCat.Client" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The only changes from previous iteration concern the logger adapter: messages are now always formatted using `InvariantCulture` (let me know if this isn't what we want) and `ArgumentOutOfRangeException` is now thrown instead of `IndexOutOfRangeException` which is apparently runtime-reserved type.