### PR TITLE
Collect CQRS metrics

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -102,6 +102,7 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" />
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
 
+    <PackageReference Update="Microsoft.Extensions.Telemetry.Testing" Version="8.0.0-rc.2.23510.2" />
     <PackageReference Update="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23510.2" />
 
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="$(AspNetCoreVersion)" />

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSMetrics.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSMetrics.cs
@@ -1,20 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using LeanCode.OpenTelemetry;
 
 namespace LeanCode.CQRS.AspNetCore;
 
-internal class CQRSMetrics
+public class CQRSMetrics
 {
-    private static readonly Counter<int> cqrsSuccess = LeanCodeMetrics.CreateCounter<int>("cqrs.success");
-    private static readonly Counter<int> cqrsFailure = LeanCodeMetrics.CreateCounter<int>("cqrs.failure");
-
-    public static void CQRSSuccess() => cqrsSuccess.Add(1);
-
-    public static void CQRSFailure(string reason) =>
-        cqrsFailure.Add(1, KeyValuePair.Create("reason", reason as object)!);
-
     public const string SerializationFailure = "serialization";
     public const string AuthorizationFailure = "authorization";
     public const string ValidationFailure = "validation";
     public const string InternalError = "internal_error";
+
+    private readonly Counter<int> cqrsSuccess;
+    private readonly Counter<int> cqrsFailure;
+
+    [SuppressMessage("?", "CA2000", Justification = "Meter lifetime if managed by DI and it doesn't need to be disposed manually")]
+    public CQRSMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(LeanCodeMetrics.MeterName);
+
+        cqrsSuccess = meter.CreateCounter<int>("cqrs.success");
+        cqrsFailure = meter.CreateCounter<int>("cqrs.failure");
+    }
+
+    public void CQRSSuccess() => cqrsSuccess.Add(1);
+
+    public void CQRSFailure(string reason) => cqrsFailure.Add(1, KeyValuePair.Create("reason", reason as object)!);
 }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSMetrics.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSMetrics.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.Metrics;
+using LeanCode.OpenTelemetry;
+
+namespace LeanCode.CQRS.AspNetCore;
+
+internal class CQRSMetrics
+{
+    private static readonly Counter<int> cqrsSuccess = LeanCodeMetrics.CreateCounter<int>("cqrs.success");
+    private static readonly Counter<int> cqrsFailure = LeanCodeMetrics.CreateCounter<int>("cqrs.failure");
+
+    public static void CQRSSuccess() => cqrsSuccess.Add(1);
+
+    public static void CQRSFailure(string reason) =>
+        cqrsFailure.Add(1, KeyValuePair.Create("reason", reason as object)!);
+
+    public const string SerializationFailure = "serialization";
+    public const string AuthorizationFailure = "authorization";
+    public const string ValidationFailure = "validation";
+    public const string InternalError = "internal_error";
+}

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSMetrics.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSMetrics.cs
@@ -14,7 +14,11 @@ public class CQRSMetrics
     private readonly Counter<int> cqrsSuccess;
     private readonly Counter<int> cqrsFailure;
 
-    [SuppressMessage("?", "CA2000", Justification = "Meter lifetime if managed by DI and it doesn't need to be disposed manually")]
+    [SuppressMessage(
+        "?",
+        "CA2000",
+        Justification = "Meter lifetime if managed by DI and it doesn't need to be disposed manually"
+    )]
     public CQRSMetrics(IMeterFactory meterFactory)
     {
         var meter = meterFactory.Create(LeanCodeMetrics.MeterName);

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSExceptionTranslationMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSExceptionTranslationMiddleware.cs
@@ -10,10 +10,12 @@ namespace LeanCode.CQRS.AspNetCore.Middleware;
 public class CQRSExceptionTranslationMiddleware
 {
     private readonly ILogger logger = Log.ForContext<CQRSExceptionTranslationMiddleware>();
+    private readonly CQRSMetrics metrics;
     private readonly RequestDelegate next;
 
-    public CQRSExceptionTranslationMiddleware(RequestDelegate next)
+    public CQRSExceptionTranslationMiddleware(CQRSMetrics metrics, RequestDelegate next)
     {
+        this.metrics = metrics;
         this.next = next;
     }
 
@@ -37,6 +39,7 @@ public class CQRSExceptionTranslationMiddleware
             logger.Warning("Command {@Command} is not valid with result {@Result}", cqrsPayload.Payload, result);
             var executionResult = ExecutionResult.WithPayload(result, StatusCodes.Status422UnprocessableEntity);
             cqrsPayload.SetResult(executionResult);
+            metrics.CQRSFailure(CQRSMetrics.ValidationFailure);
         }
     }
 

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
@@ -29,6 +29,7 @@ public class CQRSSecurityMiddleware
             logger.Warning("The current user is not authenticated and the object requires authorization");
 
             payload.SetResult(ExecutionResult.Empty(StatusCodes.Status401Unauthorized));
+            CQRSMetrics.CQRSFailure(CQRSMetrics.AuthorizationFailure);
             return;
         }
 
@@ -57,6 +58,7 @@ public class CQRSSecurityMiddleware
                 );
 
                 payload.SetResult(ExecutionResult.Empty(StatusCodes.Status403Forbidden));
+                CQRSMetrics.CQRSFailure(CQRSMetrics.AuthorizationFailure);
                 return;
             }
         }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
@@ -8,11 +8,13 @@ namespace LeanCode.CQRS.AspNetCore.Middleware;
 
 public class CQRSSecurityMiddleware
 {
+    private readonly CQRSMetrics metrics;
     private readonly RequestDelegate next;
     private readonly ILogger logger = Log.ForContext<CQRSSecurityMiddleware>();
 
-    public CQRSSecurityMiddleware(RequestDelegate next)
+    public CQRSSecurityMiddleware(CQRSMetrics metrics, RequestDelegate next)
     {
+        this.metrics = metrics;
         this.next = next;
     }
 
@@ -29,7 +31,7 @@ public class CQRSSecurityMiddleware
             logger.Warning("The current user is not authenticated and the object requires authorization");
 
             payload.SetResult(ExecutionResult.Empty(StatusCodes.Status401Unauthorized));
-            CQRSMetrics.CQRSFailure(CQRSMetrics.AuthorizationFailure);
+            metrics.CQRSFailure(CQRSMetrics.AuthorizationFailure);
             return;
         }
 
@@ -58,7 +60,7 @@ public class CQRSSecurityMiddleware
                 );
 
                 payload.SetResult(ExecutionResult.Empty(StatusCodes.Status403Forbidden));
-                CQRSMetrics.CQRSFailure(CQRSMetrics.AuthorizationFailure);
+                metrics.CQRSFailure(CQRSMetrics.AuthorizationFailure);
                 return;
             }
         }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSValidationMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSValidationMiddleware.cs
@@ -9,10 +9,12 @@ public class CQRSValidationMiddleware
 {
     private readonly Serilog.ILogger logger = Serilog.Log.ForContext<CQRSValidationMiddleware>();
 
+    private readonly CQRSMetrics metrics;
     private readonly RequestDelegate next;
 
-    public CQRSValidationMiddleware(RequestDelegate next)
+    public CQRSValidationMiddleware(CQRSMetrics metrics, RequestDelegate next)
     {
+        this.metrics = metrics;
         this.next = next;
     }
 
@@ -37,7 +39,7 @@ public class CQRSValidationMiddleware
                 logger.Warning("Command {@Command} is not valid with result {@Result}", payload.Payload, result);
                 var commandResult = CommandResult.NotValid(result);
                 payload.SetResult(ExecutionResult.WithPayload(commandResult, StatusCodes.Status422UnprocessableEntity));
-                CQRSMetrics.CQRSFailure(CQRSMetrics.ValidationFailure);
+                metrics.CQRSFailure(CQRSMetrics.ValidationFailure);
                 return;
             }
         }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSValidationMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSValidationMiddleware.cs
@@ -37,6 +37,7 @@ public class CQRSValidationMiddleware
                 logger.Warning("Command {@Command} is not valid with result {@Result}", payload.Payload, result);
                 var commandResult = CommandResult.NotValid(result);
                 payload.SetResult(ExecutionResult.WithPayload(commandResult, StatusCodes.Status422UnprocessableEntity));
+                CQRSMetrics.CQRSFailure(CQRSMetrics.ValidationFailure);
                 return;
             }
         }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionCQRSExtensions
         var objectsSource = new CQRSObjectsRegistrationSource(serviceCollection);
         objectsSource.AddCQRSObjects(contractsCatalog, handlersCatalog);
 
+        serviceCollection.AddSingleton<CQRSMetrics>();
         serviceCollection.AddSingleton(objectsSource);
 
         serviceCollection.AddSingleton<RoleRegistry>();

--- a/src/Infrastructure/LeanCode.OpenTelemetry/LeanCodeMetrics.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/LeanCodeMetrics.cs
@@ -4,8 +4,5 @@ namespace LeanCode.OpenTelemetry;
 
 public static class LeanCodeMetrics
 {
-    public static readonly Meter Meter = new("LeanCode.CoreLibrary");
-
-    public static Counter<T> CreateCounter<T>(string name)
-        where T : struct => Meter.CreateCounter<T>(name);
+    public const string MeterName = "LeanCode.CoreLibrary";
 }

--- a/src/Infrastructure/LeanCode.OpenTelemetry/LeanCodeMetrics.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/LeanCodeMetrics.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.Metrics;
+
+namespace LeanCode.OpenTelemetry;
+
+public static class LeanCodeMetrics
+{
+    public static readonly Meter Meter = new("LeanCode.CoreLibrary");
+
+    public static Counter<T> CreateCounter<T>(string name)
+        where T : struct => Meter.CreateCounter<T>(name);
+}

--- a/src/Infrastructure/LeanCode.OpenTelemetry/MeterBuilderExtensions.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/MeterBuilderExtensions.cs
@@ -1,0 +1,11 @@
+using OpenTelemetry.Metrics;
+
+namespace LeanCode.OpenTelemetry;
+
+public static class MeterBuilderExtensions
+{
+    public static MeterProviderBuilder AddLeanCodeMetrics(this MeterProviderBuilder builder)
+    {
+        return builder.AddMeter(LeanCodeMetrics.Meter.Name);
+    }
+}

--- a/src/Infrastructure/LeanCode.OpenTelemetry/MeterBuilderExtensions.cs
+++ b/src/Infrastructure/LeanCode.OpenTelemetry/MeterBuilderExtensions.cs
@@ -6,6 +6,6 @@ public static class MeterBuilderExtensions
 {
     public static MeterProviderBuilder AddLeanCodeMetrics(this MeterProviderBuilder builder)
     {
-        return builder.AddMeter(LeanCodeMetrics.Meter.Name);
+        return builder.AddMeter(LeanCodeMetrics.MeterName);
     }
 }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/LeanCode.CQRS.AspNetCore.Tests.csproj
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/LeanCode.CQRS.AspNetCore.Tests.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+        <PackageReference Include="Microsoft.Extensions.Telemetry.Testing" />
     </ItemGroup>
 
 </Project>

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSExceptionTranslationMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSExceptionTranslationMiddlewareTests.cs
@@ -1,69 +1,45 @@
 using FluentAssertions;
 using LeanCode.Contracts;
+using LeanCode.Contracts.Validation;
 using LeanCode.CQRS.AspNetCore.Middleware;
 using LeanCode.CQRS.Execution;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace LeanCode.CQRS.AspNetCore.Tests.Middleware;
 
-public sealed class CQRSExceptionTranslationMiddlewareTests : IDisposable, IAsyncLifetime
+public sealed class CQRSExceptionTranslationMiddlewareTests : CQRSMiddlewareTestBase<CQRSExceptionTranslationMiddleware>
 {
-    private readonly IHost host;
-    private readonly TestServer server;
-
-    private RequestDelegate finalPipeline;
-
-    public CQRSExceptionTranslationMiddlewareTests()
-    {
-        finalPipeline = _ => Task.CompletedTask;
-        host = new HostBuilder()
-            .ConfigureWebHost(webHost =>
-            {
-                webHost
-                    .UseTestServer()
-                    .Configure(app =>
-                    {
-                        app.UseMiddleware<CQRSExceptionTranslationMiddleware>();
-                        app.Run(ctx => finalPipeline(ctx));
-                    });
-            })
-            .Build();
-        server = host.GetTestServer();
-    }
-
     [Fact]
     public async Task If_CommandExecutionInvalidException_is_thrown_its_translated()
     {
-        finalPipeline = _ => throw new CommandExecutionInvalidException(23, "error message");
+        FinalPipeline = _ => throw new CommandExecutionInvalidException(23, "error message");
 
         var httpContext = await SendAsync();
 
-        var executionResult = ExtractExecutionResult(httpContext);
-        executionResult.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
-        var commandResult = ExtractCommandResult(executionResult);
-        var error = commandResult.ValidationErrors.Should().ContainSingle().Which;
-        error.ErrorCode.Should().Be(23);
-        error.ErrorMessage.Should().Be("error message");
+        httpContext
+            .ShouldContainExecutionResult(StatusCodes.Status422UnprocessableEntity)
+            .ShouldContainCommandResult()
+            .ShouldFailWithValidationErrors(new ValidationError("", "error message", 23));
+
+        VerifyCQRSFailureMetrics(CQRSMetrics.ValidationFailure, 1);
     }
 
     [Fact]
     public async Task If_other_exception_is_thrown_its_propagated()
     {
-        finalPipeline = _ => throw new InvalidOperationException("error message");
+        FinalPipeline = _ => throw new InvalidOperationException("error message");
 
         var errorRequest = SendAsync;
         await errorRequest.Should().ThrowAsync<InvalidOperationException>();
+
+        VerifyCQRSFailureMetrics(CQRSMetrics.ValidationFailure, 0);
     }
 
     [Fact]
     public async Task Regular_flow_is_not_interrupted()
     {
-        finalPipeline = ctx =>
+        FinalPipeline = ctx =>
         {
             ctx.GetCQRSRequestPayload().SetResult(ExecutionResult.WithPayload(CommandResult.Success));
             return Task.CompletedTask;
@@ -71,15 +47,17 @@ public sealed class CQRSExceptionTranslationMiddlewareTests : IDisposable, IAsyn
 
         var httpContext = await SendAsync();
 
-        var executionResult = ExtractExecutionResult(httpContext);
-        executionResult.StatusCode.Should().Be(StatusCodes.Status200OK);
-        var commandResult = ExtractCommandResult(executionResult);
-        commandResult.WasSuccessful.Should().BeTrue();
+        httpContext
+            .ShouldContainExecutionResult(StatusCodes.Status200OK)
+            .ShouldContainCommandResult()
+            .ShouldBeSuccessful();
+
+        VerifyCQRSFailureMetrics(CQRSMetrics.ValidationFailure, 0);
     }
 
     private Task<HttpContext> SendAsync()
     {
-        return server.SendAsync(ctx =>
+        return Server.SendAsync(ctx =>
         {
             var cqrsMetadata = new CQRSObjectMetadata(
                 CQRSObjectKind.Command,
@@ -91,29 +69,6 @@ public sealed class CQRSExceptionTranslationMiddlewareTests : IDisposable, IAsyn
             ctx.SetEndpoint(TestHelpers.MockCQRSEndpoint(cqrsMetadata));
             ctx.SetCQRSRequestPayload(new Command());
         });
-    }
-
-    private static ExecutionResult ExtractExecutionResult(HttpContext httpContext)
-    {
-        var cqrsPayload = httpContext.GetCQRSRequestPayload();
-
-        cqrsPayload.Result.Should().NotBeNull();
-        return cqrsPayload.Result!.Value;
-    }
-
-    private static CommandResult ExtractCommandResult(ExecutionResult result)
-    {
-        return result.Payload.Should().BeOfType<CommandResult>().Subject;
-    }
-
-    public Task InitializeAsync() => host.StartAsync();
-
-    public Task DisposeAsync() => host.StopAsync();
-
-    public void Dispose()
-    {
-        server.Dispose();
-        host.Dispose();
     }
 
     private sealed class Command : ICommand { }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTestBase.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTestBase.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using LeanCode.OpenTelemetry;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace LeanCode.CQRS.AspNetCore.Tests.Middleware;
+
+public abstract class CQRSMiddlewareTestBase<TMiddleware> : IAsyncLifetime
+{
+    private readonly MetricCollector<int> cqrsSuccessMetricCollector;
+    private readonly MetricCollector<int> cqrsFailureMetricCollector;
+    protected IHost Host { get; }
+    protected TestServer Server { get; }
+
+    protected RequestDelegate FinalPipeline { get; set; } = ctx => Task.CompletedTask;
+
+    protected virtual void ConfigureServices(IServiceCollection services) { }
+
+    protected CQRSMiddlewareTestBase()
+    {
+        Host = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddSingleton<CQRSMetrics>();
+                        ConfigureServices(services);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseMiddleware<TMiddleware>();
+                        app.Run(ctx => FinalPipeline(ctx));
+                    });
+            })
+            .Build();
+
+        Server = Host.GetTestServer();
+
+        var meterFactory = Host.Services.GetRequiredService<IMeterFactory>();
+
+        cqrsSuccessMetricCollector = new MetricCollector<int>(meterFactory, LeanCodeMetrics.MeterName, "cqrs.success");
+        cqrsFailureMetricCollector = new MetricCollector<int>(meterFactory, LeanCodeMetrics.MeterName, "cqrs.failure");
+    }
+
+    protected void VerifyCQRSSuccessMetrics(int measuredTotal)
+    {
+        var snapshot = cqrsSuccessMetricCollector.GetMeasurementSnapshot();
+        var metric = snapshot.Sum(s => s.Value);
+        metric.Should().Be(measuredTotal, "cqrs success metric should be equal {0}", measuredTotal);
+
+        VerifyNoCQRSFailureMetrics();
+    }
+
+    protected void VerifyNoCQRSFailureMetrics()
+    {
+        var snapshot = cqrsFailureMetricCollector.GetMeasurementSnapshot();
+        var metric = snapshot.Sum(m => m.Value);
+        metric.Should().Be(0, "there should be no error metrics");
+    }
+
+    protected void VerifyCQRSFailureMetrics(string reason, int measuredTotal)
+    {
+        var snapshot = cqrsFailureMetricCollector.GetMeasurementSnapshot();
+
+        var metric = snapshot
+            .Where(m => m.MatchesTags(KeyValuePair.Create<string, object?>("reason", reason)))
+            .Sum(m => m.Value);
+
+        metric.Should().Be(measuredTotal, "collected `{0}` metric should be equal to {1}", reason, measuredTotal);
+        VerifyNoCQRSSuccessMetrics();
+    }
+
+    protected void VerifyNoCQRSSuccessMetrics()
+    {
+        var snapshot = cqrsSuccessMetricCollector.GetMeasurementSnapshot();
+        var metric = snapshot.Sum(m => m.Value);
+        metric.Should().Be(0, "there should be no success metrics");
+    }
+
+    public Task InitializeAsync() => Host.StartAsync();
+
+    public Task DisposeAsync() => Host.StopAsync();
+}

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTestBase.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTestBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using FluentAssertions;
 using LeanCode.OpenTelemetry;
@@ -12,7 +13,8 @@ using Xunit;
 
 namespace LeanCode.CQRS.AspNetCore.Tests.Middleware;
 
-public abstract class CQRSMiddlewareTestBase<TMiddleware> : IAsyncLifetime
+[SuppressMessage("?", "CA1063", Justification = "Demands a Dispose(bool) pattern which is not applicable")]
+public abstract class CQRSMiddlewareTestBase<TMiddleware> : IAsyncLifetime, IDisposable
 {
     private readonly MetricCollector<int> cqrsSuccessMetricCollector;
     private readonly MetricCollector<int> cqrsFailureMetricCollector;
@@ -89,4 +91,13 @@ public abstract class CQRSMiddlewareTestBase<TMiddleware> : IAsyncLifetime
     public Task InitializeAsync() => Host.StartAsync();
 
     public Task DisposeAsync() => Host.StopAsync();
+
+    public void Dispose()
+    {
+        Server.Dispose();
+        Host.Dispose();
+
+        cqrsSuccessMetricCollector.Dispose();
+        cqrsFailureMetricCollector.Dispose();
+    }
 }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
@@ -5,12 +5,8 @@ using LeanCode.Contracts.Security;
 using LeanCode.CQRS.AspNetCore.Middleware;
 using LeanCode.CQRS.Execution;
 using LeanCode.CQRS.Security;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using Xunit;
 
@@ -18,61 +14,45 @@ namespace LeanCode.CQRS.AspNetCore.Tests.Middleware;
 
 [SuppressMessage(category: "?", "CA1034", Justification = "Nesting public types for better tests separation")]
 [SuppressMessage(category: "?", "CA1040", Justification = "Empty marker interfaces")]
-public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
+public sealed class CQRSSecurityMiddlewareTests : CQRSMiddlewareTestBase<CQRSSecurityMiddleware>
 {
     private const string SingleAuthorizerCustomData = nameof(SingleAuthorizerCustomData);
 
-    private readonly IHost host;
-    private readonly TestServer server;
-
-    private readonly ICustomAuthorizer firstAuthorizer;
-    private readonly IHttpContextCustomAuthorizer secondAuthorizer;
+    private readonly ICustomAuthorizer firstAuthorizer = Substitute.For<ICustomAuthorizer, IFirstAuthorizer>();
+    private readonly IHttpContextCustomAuthorizer secondAuthorizer = Substitute.For<
+        IHttpContextCustomAuthorizer,
+        ISecondAuthorizer
+    >();
 
     private static ClaimsPrincipal AuthenticatedUser() => new(new ClaimsIdentity("TEST"));
 
     public CQRSSecurityMiddlewareTests()
     {
-        firstAuthorizer = Substitute.For<ICustomAuthorizer, IFirstAuthorizer>();
-        secondAuthorizer = Substitute.For<IHttpContextCustomAuthorizer, ISecondAuthorizer>();
+        FinalPipeline = ctx =>
+        {
+            ctx.GetCQRSRequestPayload().SetResult(ExecutionResult.WithPayload(null));
+            return Task.CompletedTask;
+        };
+    }
 
-        host = new HostBuilder()
-            .ConfigureWebHost(webHost =>
-            {
-                webHost
-                    .UseTestServer()
-                    .ConfigureServices(cfg =>
-                    {
-                        cfg.AddSingleton((firstAuthorizer as IFirstAuthorizer)!);
-                        cfg.AddSingleton((secondAuthorizer as ISecondAuthorizer)!);
-                    })
-                    .Configure(app =>
-                    {
-                        app.UseMiddleware<CQRSSecurityMiddleware>();
-                        app.Run(ctx =>
-                        {
-                            var payload = ctx.GetCQRSRequestPayload();
-                            payload.SetResult(ExecutionResult.WithPayload(null));
-                            return Task.CompletedTask;
-                        });
-                    });
-            })
-            .Build();
-
-        server = host.GetTestServer();
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSingleton(_ => (firstAuthorizer as IFirstAuthorizer)!);
+        services.AddSingleton(_ => (secondAuthorizer as ISecondAuthorizer)!);
     }
 
     [Fact]
     public async Task Does_not_require_user_authentication_if_object_does_not_have_authorizers()
     {
         var httpContext = await SendPayloadAsync(new NoAuthorization());
-        AssertExecutionResult(httpContext, StatusCodes.Status200OK);
+        AssertAuthorizationSuccess(httpContext);
     }
 
     [Fact]
     public async Task Returns_401Unauthorized_if_object_has_authorizers_and_user_is_not_authenticated()
     {
         var httpContext = await SendPayloadAsync(new SingleAuthorizer());
-        AssertExecutionResult(httpContext, StatusCodes.Status401Unauthorized);
+        AssertAuthorizationFailure(httpContext, StatusCodes.Status401Unauthorized);
     }
 
     [Theory]
@@ -84,24 +64,40 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
 
         var httpContext = await SendPayloadAsync(new SingleAuthorizer(), AuthenticatedUser());
 
-        var expectedCode = isPositive ? StatusCodes.Status200OK : StatusCodes.Status403Forbidden;
-        AssertExecutionResult(httpContext, expectedCode);
+        if (isPositive)
+        {
+            AssertAuthorizationSuccess(httpContext);
+        }
+        else
+        {
+            AssertAuthorizationFailure(httpContext);
+        }
     }
 
     [Theory]
-    [InlineData(false, false)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(true, true)]
-    public async Task Object_with_multiple_authorizers_authorize_accordingly(bool firstPositive, bool secondPositive)
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, true)]
+    public async Task Object_with_multiple_authorizers_authorize_accordingly(
+        bool firstPositive,
+        bool secondPositive,
+        bool expectSuccess
+    )
     {
         SetAuthorizationResultAsync(firstAuthorizer, firstPositive);
         SetAuthorizationResultAsync(secondAuthorizer, secondPositive);
 
         var httpContext = await SendPayloadAsync(new MultipleAuthorizers(), AuthenticatedUser());
 
-        var expectedCode = firstPositive && secondPositive ? StatusCodes.Status200OK : StatusCodes.Status403Forbidden;
-        AssertExecutionResult(httpContext, expectedCode);
+        if (expectSuccess)
+        {
+            AssertAuthorizationSuccess(httpContext);
+        }
+        else
+        {
+            AssertAuthorizationFailure(httpContext);
+        }
     }
 
     [Fact]
@@ -123,6 +119,20 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
             .CheckIfAuthorizedAsync(Arg.Any<HttpContext>(), cmd, SingleAuthorizerCustomData);
     }
 
+    private void AssertAuthorizationSuccess(HttpContext context)
+    {
+        context.ShouldContainExecutionResult(StatusCodes.Status200OK);
+
+        VerifyNoCQRSSuccessMetrics();
+        VerifyNoCQRSFailureMetrics();
+    }
+
+    private void AssertAuthorizationFailure(HttpContext context, int errorCode = StatusCodes.Status403Forbidden)
+    {
+        context.ShouldContainExecutionResult(errorCode);
+        VerifyCQRSFailureMetrics(CQRSMetrics.AuthorizationFailure, 1);
+    }
+
     private Task<HttpContext> SendPayloadAsync(object payload, ClaimsPrincipal? user = null)
     {
         var cqrsMetadata = new CQRSObjectMetadata(
@@ -132,7 +142,7 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
             typeof(IgnoreType)
         );
 
-        return server.SendAsync(ctx =>
+        return Server.SendAsync(ctx =>
         {
             if (user is not null)
             {
@@ -143,14 +153,6 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
             ctx.SetEndpoint(TestHelpers.MockCQRSEndpoint(cqrsMetadata));
             ctx.SetCQRSRequestPayload(payload);
         });
-    }
-
-    private static void AssertExecutionResult(HttpContext context, int statusCode)
-    {
-        var result = context.GetCQRSRequestPayload().Result;
-
-        Assert.NotNull(result);
-        Assert.Equal(statusCode, result!.Value.StatusCode);
     }
 
     private static void SetAuthorizationResultAsync(IHttpContextCustomAuthorizer authorizer, bool result)
@@ -184,14 +186,4 @@ public sealed class CQRSSecurityMiddlewareTests : IAsyncLifetime, IDisposable
     }
 
     public class IgnoreType { }
-
-    public Task InitializeAsync() => host.StartAsync();
-
-    public Task DisposeAsync() => host.StopAsync();
-
-    public void Dispose()
-    {
-        server.Dispose();
-        host.Dispose();
-    }
 }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/TestHelpers.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/TestHelpers.cs
@@ -1,3 +1,7 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using LeanCode.Contracts;
+using LeanCode.Contracts.Validation;
 using LeanCode.CQRS.Execution;
 using Microsoft.AspNetCore.Http;
 
@@ -9,5 +13,51 @@ public static class TestHelpers
     {
         var endpointMetadata = new CQRSEndpointMetadata(obj, (_, __) => Task.FromResult(null as object));
         return new Endpoint(null, new EndpointMetadataCollection(endpointMetadata), obj.ObjectType.Name);
+    }
+
+    public static ExecutionResult ShouldContainExecutionResult(this HttpContext httpContext, int statusCode)
+    {
+        var cqrsPayload = httpContext.GetCQRSRequestPayload();
+
+        cqrsPayload.Result.Should().NotBeNull("because httpContext should contain cqrs execution result");
+        var result = cqrsPayload.Result!.Value;
+        result.StatusCode.Should().Be(statusCode);
+
+        return result;
+    }
+
+    public static CommandResult ShouldContainCommandResult(this ExecutionResult executionResult)
+    {
+        return executionResult.Payload
+            .Should()
+            .BeOfType<CommandResult>("because execution result should be a command result")
+            .Subject;
+    }
+
+    public static void ShouldBeSuccessful(this CommandResult commandResult)
+    {
+        using var _ = new AssertionScope();
+        commandResult.ValidationErrors.Should().BeEmpty("command should not contain validation errors");
+        commandResult.WasSuccessful.Should().BeTrue();
+    }
+
+    public static void ShouldFailWithValidationErrors(this CommandResult commandResult, params ValidationError[] errors)
+    {
+        using var _ = new AssertionScope();
+
+        commandResult.WasSuccessful.Should().BeFalse();
+        commandResult.ValidationErrors.Should().BeEquivalentTo(errors);
+    }
+
+    public static HttpContext ShouldHaveResponseStatusCode(this HttpContext context, int statusCode)
+    {
+        context.Response.StatusCode.Should().Be(statusCode);
+        return context;
+    }
+
+    public static HttpContext ShouldHaveResponseContentType(this HttpContext context, string? contentType)
+    {
+        context.Response.ContentType.Should().Be(contentType);
+        return context;
     }
 }


### PR DESCRIPTION
I went with success and tagged failure metrics, but I can convert them to separate metric per failure. Didn't think much of the naming, any comments welcome.  
I didn't do any tests, I don't really see a sane way to do it, apart from connecting to some app.

Plus, `"{@Object} executed successfully"` log message after each command was somehow dropped when rewriting cqrs, bringing it back now.