### PR TITLE
Add temporary fix to csharpier CI step

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.26.0",
+      "version": "0.26.1",
       "commands": [
         "dotnet-csharpier"
       ]


### PR DESCRIPTION
Context: Looks like there is some issue with `dotnet tool restore`/`csharpier`. Everytime `csharpier` releases a new version (which happened recently) CI `check formatting` step fails (with `Error: Process completed with exit code 1.` and `Run "dotnet tool restore" to make the "dotnet-csharpier" command available.`) when tool version specified in `dotnet-tools.json` is different than currently released newest one (in this case 0.26.1). I was not able to find any good fix for this for now, so just bumping the version as now all CI checks will fail on check formatting step. 

I was only able to make it work on CI with `0.26.0` version by adding `dotnet tool uninstall csharpier` and then `dotnet tool install csharpier --version 0.26.0` before `dotnet tool restore`.