### PR TITLE
Adjust nullability in generated id factory methods

### DIFF
--- a/src/Domain/LeanCode.DomainModels.Generators/IdSource.cs
+++ b/src/Domain/LeanCode.DomainModels.Generators/IdSource.cs
@@ -87,7 +87,7 @@ namespace {{data.Namespace}}
         public {{data.TypeName}}(Guid v) => value = string.Create(null, stackalloc char[RawLength], $"{TypePrefix}{Separator}{v:N}");
         {{randomFactory}}
 
-        public static {{data.TypeName}} Parse(string? v)
+        public static {{data.TypeName}} Parse(string v)
         {
             if (IsValid(v))
             {
@@ -217,7 +217,7 @@ namespace {{data.Namespace}}
 
         public static {{data.TypeName}} New() => new(Ulid.NewUlid());
 
-        public static {{data.TypeName}} Parse(string? v)
+        public static {{data.TypeName}} Parse(string v)
         {
             if (TryDeconstruct(v.AsSpan(), out var ulid))
             {
@@ -343,16 +343,9 @@ namespace {{data.Namespace}}
         public {{data.TypeName}}({{backingType}} v) => Value = v;
         {{randomFactory}}
 
-        public static {{data.TypeName}} Parse({{backingType}}? v)
+        public static {{data.TypeName}} Parse({{backingType}} v)
         {
-            if (IsValid(v))
-            {
-                return new {{data.TypeName}}(v.Value);
-            }
-            else
-            {
-                throw new FormatException("The ID has invalid format. It should be a valid `{{backingType}}`.");
-            }
+            return new {{data.TypeName}}(v);
         }
 
         [return: NotNullIfNotNull("id")]

--- a/src/Domain/LeanCode.DomainModels/Ids/ITypedId.cs
+++ b/src/Domain/LeanCode.DomainModels/Ids/ITypedId.cs
@@ -17,7 +17,7 @@ public interface IPrefixedTypedId<TSelf>
 {
     string Value { get; }
     public static abstract int RawLength { get; }
-    public static abstract TSelf Parse(string? v);
+    public static abstract TSelf Parse(string v);
     public static abstract bool IsValid(string? v);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -39,7 +39,7 @@ public interface IRawTypedId<TBacking, TSelf>
     where TSelf : struct, IRawTypedId<TBacking, TSelf>
 {
     TBacking Value { get; }
-    public static abstract TSelf Parse(TBacking? v);
+    public static abstract TSelf Parse(TBacking v);
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static abstract Expression<Func<TBacking, TSelf>> FromDatabase { get; }

--- a/src/Domain/LeanCode.DomainModels/Ids/TypedIdConverter.cs
+++ b/src/Domain/LeanCode.DomainModels/Ids/TypedIdConverter.cs
@@ -12,7 +12,7 @@ public class StringTypedIdConverter<TId> : JsonConverter<TId>
     where TId : struct, IPrefixedTypedId<TId>
 {
     public override TId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-        TId.Parse(reader.GetString());
+        TId.Parse(reader.GetString() ?? throw new JsonException("Expected an id string"));
 
     public override void Write(Utf8JsonWriter writer, TId value, JsonSerializerOptions options) =>
         writer.WriteStringValue(value.Value);

--- a/test/Domain/LeanCode.DomainModels.Tests/Ids/GuidTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Ids/GuidTests.cs
@@ -46,7 +46,6 @@ public class GuidIdTests
     {
         Assert.False(TestGuidId.IsValid(null));
 
-        Assert.Throws<FormatException>(() => TestGuidId.Parse(null));
         Assert.Null(TestGuidId.ParseNullable(null));
         Assert.False(TestGuidId.TryParse(null, out var value));
         Assert.Equal(value, default);

--- a/test/Domain/LeanCode.DomainModels.Tests/Ids/IntTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Ids/IntTests.cs
@@ -35,7 +35,6 @@ public class IntIdTests
     {
         Assert.False(TestIntId.IsValid(null));
 
-        Assert.Throws<FormatException>(() => TestIntId.Parse(null));
         Assert.Null(TestIntId.ParseNullable(null));
         Assert.False(TestIntId.TryParse(null, out var value));
         Assert.Equal(value, default);

--- a/test/Domain/LeanCode.DomainModels.Tests/Ids/LongTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Ids/LongTests.cs
@@ -35,7 +35,6 @@ public class LongIdTests
     {
         Assert.False(TestLongId.IsValid(null));
 
-        Assert.Throws<FormatException>(() => TestLongId.Parse(null));
         Assert.Null(TestLongId.ParseNullable(null));
         Assert.False(TestLongId.TryParse(null, out var value));
         Assert.Equal(value, default);

--- a/test/Domain/LeanCode.DomainModels.Tests/Ids/PrefixedGuidTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Ids/PrefixedGuidTests.cs
@@ -42,7 +42,7 @@ public class PrefixedGuidIdTests
     {
         Assert.False(TestPrefixedGuidId.IsValid(null));
 
-        Assert.Throws<FormatException>(() => TestPrefixedGuidId.Parse(null));
+        Assert.Throws<FormatException>(() => TestPrefixedGuidId.Parse(null!));
         Assert.Throws<FormatException>(() => TestPrefixedGuidId.ParseNullable("invalid"));
         Assert.False(TestPrefixedGuidId.TryParse(null, out var value));
         Assert.Equal(value, default);

--- a/test/Domain/LeanCode.DomainModels.Tests/Ids/PrefixedUlidTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Ids/PrefixedUlidTests.cs
@@ -43,7 +43,7 @@ public class PrefixedUlidIdTests
     {
         TestPrefixedUlidId.IsValid(null).Should().BeFalse();
 
-        var parseNull = () => TestPrefixedUlidId.Parse(null);
+        var parseNull = () => TestPrefixedUlidId.Parse(null!);
         var parseInvalid = () => TestPrefixedUlidId.ParseNullable("invalid");
 
         parseNull.Should().Throw<FormatException>();


### PR DESCRIPTION
We had
```
TId Parse(TBacking? v)
TId? ParseNullable(TBacking? v)
bool TryParse(TBacking? v, out TId result) 
```
The first one was throwing when passed null value which was counter intuitive. Now it requires non nullable value, making intentions much cleaner.
 
