### PR TITLE
API Explorer integration

### DIFF
--- a/docs/external_integrations/api_explorer/index.md
+++ b/docs/external_integrations/api_explorer/index.md
@@ -4,13 +4,22 @@
 
 By using these tools, you get OpenAPI definitions, along the [Swagger UI](https://swagger.io/tools/swagger-ui/) tooling.
 
-The integration is available out of the box for every exposed command, query or operation.
-
 ## Packages
 
 | Package | Link | Application in section |
 | --- | ----------- | ----------- |
 | LeanCode.CQRS.AspNetCore | [![NuGet version (LeanCode.CQRS.AspNetCore)](https://img.shields.io/nuget/vpre/LeanCode.CQRS.AspNetCore.svg?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LeanCode.CQRS.AspNetCore) | Configuration |
+
+## Configuration
+
+To add the service, call the `AddCQRSApiExplorer` extension method in `ConfigureServices`:
+
+```csharp
+public override void ConfigureServices(IServiceCollection services)
+{
+    services.AddCQRSApiExplorer();
+}
+```
 
 ## JSON Casing
 

--- a/docs/external_integrations/api_explorer/index.md
+++ b/docs/external_integrations/api_explorer/index.md
@@ -1,0 +1,30 @@
+# API Explorer/Swagger integration
+
+[CQRS](../../cqrs/index.md) implementation integrates seamlessly with the [API Explorer](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.apiexplorer) functionality of ASP.NET Core. This means that every endpoint can be automatically documented by other tools that leverage it, e.g. [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) or [NSwag](https://github.com/RicoSuter/NSwag).
+
+By using these tools, you get OpenAPI definitions, along the [Swagger UI](https://swagger.io/tools/swagger-ui/) tooling.
+
+The integration is available out of the box for every exposed command, query or operation.
+
+## Packages
+
+| Package | Link | Application in section |
+| --- | ----------- | ----------- |
+| LeanCode.CQRS.AspNetCore | [![NuGet version (LeanCode.CQRS.AspNetCore)](https://img.shields.io/nuget/vpre/LeanCode.CQRS.AspNetCore.svg?style=flat-square&logo=nuget)](https://www.nuget.org/packages/LeanCode.CQRS.AspNetCore) | Configuration |
+
+## JSON Casing
+
+Every integration uses different configuration for the generated payload types. It is highly probable that the default configuration of JSON serializer for these integrations will use wrong property casing. Unfortunately, every tool is configured differently.
+
+### Swashbuckle
+
+To configure Swashbuckle, you need to register custom `ISerializerDataContractResolver` that has the same configurtion as the `ISerializer` of CQRS.
+
+```csharp
+// This will use default JSON serialization, with unchanged property names (this is the default of System.Text.Json) & CQRS
+builder
+    .Services
+    .AddTransient<ISerializerDataContractResolver>(
+        _ => new JsonSerializerDataContractResolver(new JsonSerializerOptions { PropertyNamingPolicy = null })
+    );
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,8 @@ nav:
       - ./external_integrations/observability_open_telemetry/index.md
     - Push notifications - FCM:
       - ./external_integrations/push_notifications_fcm/index.md
+    - API Explorer/Swagger:
+      - ./external_integrations/api_explorer/index.md
   - Features:
     - Audit logs:
       - ./features/audit_logs/index.md

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/CQRSApiDescriptionProvider.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/CQRSApiDescriptionProvider.cs
@@ -1,0 +1,270 @@
+using System.Collections.Immutable;
+using System.Text;
+using LeanCode.Contracts;
+using LeanCode.CQRS.Execution;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace LeanCode.CQRS.AspNetCore.Registration;
+
+internal sealed class CQRSApiDescriptionProvider : IApiDescriptionProvider
+{
+    private const string ApplicationJson = "application/json";
+
+    private readonly EndpointDataSource endpointDataSource;
+
+    public int Order => -1200;
+
+    public CQRSApiDescriptionProvider(EndpointDataSource endpointDataSource)
+    {
+        this.endpointDataSource = endpointDataSource;
+    }
+
+    public void OnProvidersExecuting(ApiDescriptionProviderContext context)
+    {
+        foreach (var endpoint in endpointDataSource.Endpoints)
+        {
+            if (
+                endpoint is RouteEndpoint routeEndpoint
+                && routeEndpoint.Metadata.GetMetadata<CQRSEndpointMetadata>() is { } metadata
+            )
+            {
+                context.Results.Add(CreateApiDescription(routeEndpoint, metadata));
+            }
+        }
+    }
+
+    public void OnProvidersExecuted(ApiDescriptionProviderContext context) { }
+
+    private static ApiDescription CreateApiDescription(RouteEndpoint routeEndpoint, CQRSEndpointMetadata metadata)
+    {
+        var apiDescription = new ApiDescription
+        {
+            HttpMethod = HttpMethod.Post.Method,
+            GroupName = null,
+            RelativePath = BuildPath(routeEndpoint.RoutePattern),
+            ActionDescriptor = new ActionDescriptor
+            {
+                DisplayName = routeEndpoint.DisplayName,
+                RouteValues = { ["controller"] = "CQRS", }, // Required by Swagger (Swashbuckle)
+            },
+        };
+        apiDescription.SupportedRequestFormats.Add(new() { MediaType = ApplicationJson });
+
+        if (metadata.ObjectMetadata.ObjectKind == CQRSObjectKind.Command)
+        {
+            DefineCommand(metadata, apiDescription);
+        }
+        else if (metadata.ObjectMetadata.ObjectKind == CQRSObjectKind.Query)
+        {
+            DefineQuery(metadata, apiDescription);
+        }
+        else if (metadata.ObjectMetadata.ObjectKind == CQRSObjectKind.Operation)
+        {
+            DefineOperation(metadata, apiDescription);
+        }
+
+        AddCommonResponses(apiDescription);
+
+        return apiDescription;
+    }
+
+    private static string BuildPath(RoutePattern pattern)
+    {
+        var sb = new StringBuilder();
+        foreach (var seg in pattern.PathSegments)
+        {
+            if (!seg.IsSimple || !seg.Parts[0].IsLiteral)
+            {
+                throw new InvalidOperationException("CQRS Endpoints can only contain literal parts.");
+            }
+            sb.Append(((RoutePatternLiteralPart)seg.Parts[0]).Content);
+            sb.Append('/');
+        }
+        sb.Remove(sb.Length - 1, 1);
+        return sb.ToString();
+    }
+
+    private static void DefineCommand(CQRSEndpointMetadata metadata, ApiDescription apiDescription)
+    {
+        apiDescription
+            .ParameterDescriptions
+            .Add(
+                new()
+                {
+                    IsRequired = true,
+                    Source = BindingSource.Body,
+                    Type = metadata.ObjectMetadata.ObjectType,
+                    ModelMetadata = CreateModelMetadata(metadata.ObjectMetadata.ObjectType),
+                }
+            );
+
+        apiDescription
+            .SupportedResponseTypes
+            .Add(
+                new()
+                {
+                    ModelMetadata = CreateModelMetadata(typeof(CommandResult)),
+                    ApiResponseFormats =  [ new() { MediaType = ApplicationJson } ],
+                    StatusCode = 200,
+                    Type = typeof(CommandResult),
+                }
+            );
+
+        apiDescription
+            .SupportedResponseTypes
+            .Add(
+                new()
+                {
+                    ModelMetadata = CreateModelMetadata(typeof(CommandResult)),
+                    ApiResponseFormats =  [ new() { MediaType = ApplicationJson } ],
+                    StatusCode = 422,
+                    Type = typeof(CommandResult),
+                }
+            );
+    }
+
+    private static void DefineQuery(CQRSEndpointMetadata metadata, ApiDescription apiDescription)
+    {
+        apiDescription
+            .ParameterDescriptions
+            .Add(
+                new()
+                {
+                    IsRequired = true,
+                    Source = BindingSource.Body,
+                    Type = metadata.ObjectMetadata.ObjectType,
+                    ModelMetadata = CreateModelMetadata(metadata.ObjectMetadata.ObjectType),
+                }
+            );
+
+        apiDescription
+            .SupportedResponseTypes
+            .Add(
+                new()
+                {
+                    ModelMetadata = CreateModelMetadata(metadata.ObjectMetadata.ResultType),
+                    ApiResponseFormats =  [ new() { MediaType = ApplicationJson } ],
+                    StatusCode = 200,
+                    Type = metadata.ObjectMetadata.ResultType,
+                }
+            );
+    }
+
+    private static void DefineOperation(CQRSEndpointMetadata metadata, ApiDescription apiDescription)
+    {
+        apiDescription
+            .ParameterDescriptions
+            .Add(
+                new()
+                {
+                    IsRequired = true,
+                    Source = BindingSource.Body,
+                    Type = metadata.ObjectMetadata.ObjectType,
+                    ModelMetadata = CreateModelMetadata(metadata.ObjectMetadata.ObjectType),
+                }
+            );
+
+        apiDescription
+            .SupportedResponseTypes
+            .Add(
+                new()
+                {
+                    ModelMetadata = CreateModelMetadata(metadata.ObjectMetadata.ResultType),
+                    ApiResponseFormats =  [ new() { MediaType = ApplicationJson } ],
+                    StatusCode = 200,
+                    Type = metadata.ObjectMetadata.ResultType,
+                }
+            );
+    }
+
+    private static void AddCommonResponses(ApiDescription apiDescription)
+    {
+        apiDescription
+            .SupportedResponseTypes
+            .Add(
+                new()
+                {
+                    ModelMetadata = CreateModelMetadata(typeof(void)),
+                    ApiResponseFormats =  [ new() { MediaType = ApplicationJson } ],
+                    StatusCode = 400,
+                    Type = typeof(void),
+                }
+            );
+
+        apiDescription
+            .SupportedResponseTypes
+            .Add(
+                new()
+                {
+                    ModelMetadata = CreateModelMetadata(typeof(void)),
+                    ApiResponseFormats =  [ new() { MediaType = ApplicationJson } ],
+                    StatusCode = 401,
+                    Type = typeof(void),
+                }
+            );
+
+        apiDescription
+            .SupportedResponseTypes
+            .Add(
+                new()
+                {
+                    ModelMetadata = CreateModelMetadata(typeof(void)),
+                    ApiResponseFormats =  [ new() { MediaType = ApplicationJson } ],
+                    StatusCode = 403,
+                    Type = typeof(void),
+                }
+            );
+    }
+
+    private static CQRSBodyModelMetadata CreateModelMetadata(Type type) => new(ModelMetadataIdentity.ForType(type));
+}
+
+internal sealed class CQRSBodyModelMetadata : ModelMetadata
+{
+    public CQRSBodyModelMetadata(ModelMetadataIdentity identity)
+        : base(identity) { }
+
+    public override IReadOnlyDictionary<object, object> AdditionalValues { get; } =
+        ImmutableDictionary<object, object>.Empty;
+    public override string? BinderModelName { get; }
+    public override Type? BinderType { get; }
+    public override BindingSource? BindingSource => BindingSource.Body;
+    public override bool ConvertEmptyStringToNull { get; }
+    public override string? DataTypeName { get; }
+    public override string? Description { get; }
+    public override string? DisplayFormatString { get; }
+    public override string? DisplayName { get; }
+    public override string? EditFormatString { get; }
+    public override ModelMetadata? ElementMetadata { get; }
+    public override IEnumerable<KeyValuePair<EnumGroupAndName, string>>? EnumGroupedDisplayNamesAndValues { get; }
+    public override IReadOnlyDictionary<string, string>? EnumNamesAndValues { get; }
+    public override bool HasNonDefaultEditFormat { get; }
+    public override bool HideSurroundingHtml { get; }
+    public override bool HtmlEncode { get; }
+    public override bool IsBindingAllowed => true;
+    public override bool IsBindingRequired => true;
+    public override bool IsEnum { get; }
+    public override bool IsFlagsEnum { get; }
+    public override bool IsReadOnly { get; }
+    public override bool IsRequired => true;
+    public override ModelBindingMessageProvider ModelBindingMessageProvider { get; } =
+        new DefaultModelBindingMessageProvider();
+    public override string? NullDisplayText { get; }
+    public override int Order { get; }
+    public override string? Placeholder { get; }
+    public override ModelPropertyCollection Properties { get; } = new(Enumerable.Empty<ModelMetadata>());
+    public override IPropertyFilterProvider? PropertyFilterProvider { get; }
+    public override Func<object, object>? PropertyGetter { get; }
+    public override Action<object, object?>? PropertySetter { get; }
+    public override bool ShowForDisplay { get; }
+    public override bool ShowForEdit { get; }
+    public override string? SimpleDisplayProperty { get; }
+    public override string? TemplateHint { get; }
+    public override bool ValidateChildren { get; }
+    public override IReadOnlyList<object> ValidatorMetadata { get; } = Array.Empty<object>();
+}

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
@@ -6,6 +6,7 @@ using LeanCode.CQRS.AspNetCore.Serialization;
 using LeanCode.CQRS.Execution;
 using LeanCode.CQRS.Security;
 using LeanCode.CQRS.Validation;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -30,6 +31,7 @@ public static class ServiceCollectionCQRSExtensions
         serviceCollection.AddSingleton<RoleRegistry>();
         serviceCollection.AddScoped<IHasPermissions, DefaultPermissionAuthorizer>();
         serviceCollection.AddScoped<ICommandValidatorResolver, CommandValidatorResolver>();
+        serviceCollection.AddTransient<IApiDescriptionProvider, CQRSApiDescriptionProvider>();
 
         return new CQRSServicesBuilder(serviceCollection, objectsSource);
     }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
@@ -31,9 +31,14 @@ public static class ServiceCollectionCQRSExtensions
         serviceCollection.AddSingleton<RoleRegistry>();
         serviceCollection.AddScoped<IHasPermissions, DefaultPermissionAuthorizer>();
         serviceCollection.AddScoped<ICommandValidatorResolver, CommandValidatorResolver>();
-        serviceCollection.AddTransient<IApiDescriptionProvider, CQRSApiDescriptionProvider>();
 
         return new CQRSServicesBuilder(serviceCollection, objectsSource);
+    }
+
+    public static IServiceCollection AddCQRSApiExplorer(this IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddTransient<IApiDescriptionProvider, CQRSApiDescriptionProvider>();
+        return serviceCollection;
     }
 }
 

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Registration/CQRSApiDescriptionProviderTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Registration/CQRSApiDescriptionProviderTests.cs
@@ -1,16 +1,14 @@
 using FluentAssertions;
 using LeanCode.Components;
 using LeanCode.Contracts;
-using LeanCode.Contracts.Validation;
-using LeanCode.CQRS.AspNetCore.Middleware;
 using LeanCode.CQRS.AspNetCore.Registration;
 using LeanCode.CQRS.Execution;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace LeanCode.CQRS.AspNetCore.Tests.Registration;
@@ -24,6 +22,18 @@ public class CQRSApiDescriptionProviderTests
     [
         new ApiRequestFormat { MediaType = "application/json" }
     ];
+
+    [Fact]
+    public void ApiDescriptionProvider_is_registered_correctly()
+    {
+        var sc = new ServiceCollection();
+        sc.AddTransient<EndpointDataSource, DummyEndpointDataSource>();
+        sc.AddCQRSApiExplorer();
+        var provider = sc.BuildServiceProvider();
+
+        var providers = provider.GetService<IEnumerable<IApiDescriptionProvider>>();
+        providers.Should().ContainSingle().Which.Should().BeOfType<CQRSApiDescriptionProvider>();
+    }
 
     [Fact]
     public void Describes_base_query_parameters()
@@ -229,4 +239,11 @@ public class OperationOH : IOperationHandler<Operation, OperationResultDTO>
 {
     public Task<OperationResultDTO> ExecuteAsync(HttpContext context, Operation operation) =>
         throw new NotImplementedException();
+}
+
+internal class DummyEndpointDataSource : EndpointDataSource
+{
+    public override IReadOnlyList<Endpoint> Endpoints => throw new NotImplementedException();
+
+    public override IChangeToken GetChangeToken() => throw new NotImplementedException();
 }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Registration/CQRSApiDescriptionProviderTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Registration/CQRSApiDescriptionProviderTests.cs
@@ -1,0 +1,232 @@
+using FluentAssertions;
+using LeanCode.Components;
+using LeanCode.Contracts;
+using LeanCode.Contracts.Validation;
+using LeanCode.CQRS.AspNetCore.Middleware;
+using LeanCode.CQRS.AspNetCore.Registration;
+using LeanCode.CQRS.Execution;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace LeanCode.CQRS.AspNetCore.Tests.Registration;
+
+public class CQRSApiDescriptionProviderTests
+{
+    private const string BasePath = "cqrs";
+
+    private static readonly Dictionary<string, string?> ExpectedRouteValues = new() { ["controller"] = "CQRS" };
+    private static readonly List<ApiRequestFormat> ExpectedRequestFormat =
+    [
+        new ApiRequestFormat { MediaType = "application/json" }
+    ];
+
+    [Fact]
+    public void Describes_base_query_parameters()
+    {
+        var allDescriptors = ListApisFor<Query>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+
+        query.HttpMethod.Should().Be("POST");
+        query.RelativePath.Should().Be($"{BasePath}/query/{typeof(Query).FullName}");
+        query.ActionDescriptor.DisplayName.Should().Be($"Query {typeof(Query).FullName}");
+        query.ActionDescriptor.RouteValues.Should().BeEquivalentTo(ExpectedRouteValues);
+        query.SupportedRequestFormats.Should().BeEquivalentTo(ExpectedRequestFormat);
+    }
+
+    [Fact]
+    public void Query_has_a_single_parameter_that_describes_body()
+    {
+        var allDescriptors = ListApisFor<Query>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+        query.ParameterDescriptions.Should().ContainSingle().Which.Should().BeEquivalentTo(RequestOf<Query>());
+    }
+
+    [Fact]
+    public void Query_defines_all_responses()
+    {
+        var allDescriptors = ListApisFor<Query>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+        query
+            .SupportedResponseTypes
+            .Should()
+            .BeEquivalentTo(
+                [ ResponseOf<QueryResultDTO>(200), ResponseOfVoid(400), ResponseOfVoid(401), ResponseOfVoid(403), ]
+            );
+    }
+
+    [Fact]
+    public void Describes_base_command_parameters()
+    {
+        var allDescriptors = ListApisFor<Command>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+
+        query.HttpMethod.Should().Be("POST");
+        query.RelativePath.Should().Be($"{BasePath}/command/{typeof(Command).FullName}");
+        query.ActionDescriptor.DisplayName.Should().Be($"Command {typeof(Command).FullName}");
+        query.ActionDescriptor.RouteValues.Should().BeEquivalentTo(ExpectedRouteValues);
+        query.SupportedRequestFormats.Should().BeEquivalentTo(ExpectedRequestFormat);
+    }
+
+    [Fact]
+    public void Command_has_a_single_parameter_that_describes_body()
+    {
+        var allDescriptors = ListApisFor<Command>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+        query.ParameterDescriptions.Should().ContainSingle().Which.Should().BeEquivalentTo(RequestOf<Command>());
+    }
+
+    [Fact]
+    public void Command_defines_all_responses()
+    {
+        var allDescriptors = ListApisFor<Command>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+        query
+            .SupportedResponseTypes
+            .Should()
+            .BeEquivalentTo(
+                [
+                    ResponseOf<CommandResult>(200),
+                    ResponseOf<CommandResult>(422),
+                    ResponseOfVoid(400),
+                    ResponseOfVoid(401),
+                    ResponseOfVoid(403),
+                ]
+            );
+    }
+
+    [Fact]
+    public void Describes_base_operation_parameters()
+    {
+        var allDescriptors = ListApisFor<Operation>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+
+        query.HttpMethod.Should().Be("POST");
+        query.RelativePath.Should().Be($"{BasePath}/operation/{typeof(Operation).FullName}");
+        query.ActionDescriptor.DisplayName.Should().Be($"Operation {typeof(Operation).FullName}");
+        query.ActionDescriptor.RouteValues.Should().BeEquivalentTo(ExpectedRouteValues);
+        query.SupportedRequestFormats.Should().BeEquivalentTo(ExpectedRequestFormat);
+    }
+
+    [Fact]
+    public void Operation_has_a_single_parameter_that_describes_body()
+    {
+        var allDescriptors = ListApisFor<Operation>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+        query.ParameterDescriptions.Should().ContainSingle().Which.Should().BeEquivalentTo(RequestOf<Operation>());
+    }
+
+    [Fact]
+    public void Operation_defines_all_responses()
+    {
+        var allDescriptors = ListApisFor<Operation>();
+
+        var query = allDescriptors.Should().ContainSingle().Which;
+        query
+            .SupportedResponseTypes
+            .Should()
+            .BeEquivalentTo(
+                [ ResponseOf<OperationResultDTO>(200), ResponseOfVoid(400), ResponseOfVoid(401), ResponseOfVoid(403), ]
+            );
+    }
+
+    private static object RequestOf<T>()
+    {
+        return new
+        {
+            IsRequired = true,
+            Source = BindingSource.Body,
+            Type = typeof(T),
+            ModelMetadata = new { Identity = new { ModelType = typeof(T) } },
+        };
+    }
+
+    private static object ResponseOf<T>(int statusCode)
+    {
+        return new
+        {
+            ApiResponseFormats = new[] { new { MediaType = "application/json" } },
+            StatusCode = statusCode,
+            Type = typeof(T),
+            ModelMetadata = new { Identity = new { ModelType = typeof(T) } },
+        };
+    }
+
+    private static object ResponseOfVoid(int statusCode)
+    {
+        return new
+        {
+            ApiResponseFormats = new[] { new { MediaType = "application/json" } },
+            StatusCode = statusCode,
+            Type = typeof(void),
+            ModelMetadata = new { Identity = new { ModelType = typeof(void) } },
+        };
+    }
+
+    private static List<ApiDescription> ListApisFor<T>()
+    {
+        return ListApis(typeof(T));
+    }
+
+    private static List<ApiDescription> ListApis(Type forObject)
+    {
+        var dataSource = CreateDataSource(forObject);
+        var context = new ApiDescriptionProviderContext([ ]);
+        new CQRSApiDescriptionProvider(dataSource).OnProvidersExecuting(context);
+        return context.Results.ToList();
+    }
+
+    private static CQRSEndpointsDataSource CreateDataSource(Type forObject)
+    {
+        var selfCatalog = TypesCatalog.Of<CQRSApiDescriptionProviderTests>();
+        var regSource = new CQRSObjectsRegistrationSource(new ServiceCollection());
+        regSource.AddCQRSObjects(selfCatalog, selfCatalog);
+
+        var dataSource = new CQRSEndpointsDataSource("/" + BasePath, new ObjectExecutorFactory());
+        dataSource.AddEndpointsFor(
+            regSource.Objects.Where(o => o.ObjectType == forObject),
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask,
+            _ => Task.CompletedTask
+        );
+        return dataSource;
+    }
+}
+
+public record QueryResultDTO();
+
+public record Query() : IQuery<QueryResultDTO>;
+
+public class QueryQH : IQueryHandler<Query, QueryResultDTO>
+{
+    public Task<QueryResultDTO> ExecuteAsync(HttpContext context, Query query) => throw new NotImplementedException();
+}
+
+public record Command() : ICommand;
+
+public class CommandCH : ICommandHandler<Command>
+{
+    public Task ExecuteAsync(HttpContext context, Command command) => throw new NotImplementedException();
+}
+
+public record OperationResultDTO();
+
+public record Operation() : IOperation<OperationResultDTO>;
+
+public class OperationOH : IOperationHandler<Operation, OperationResultDTO>
+{
+    public Task<OperationResultDTO> ExecuteAsync(HttpContext context, Operation operation) =>
+        throw new NotImplementedException();
+}


### PR DESCRIPTION
This PR adds integration to the ASP.NET Core MVC API Explorer. This also enables Swashbuckle and NSwag, thus giving us full OpenAPI & Swagger UI for "free".

It does not work OOTB because the default Minimal APIs integration requires every endpoint to have a [`MethodInfo`](https://github.com/dotnet/aspnetcore/blob/bd016947b6928159814950c06a6e2278be7a256f/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs#L63) metadata. It then uses it to generate parameter/response definitions. Unfortunately, this won't work for us as we have a slightly different model. That's why we need to register the endpoints manually.