### PR TITLE
Ensure that `ObjectExecutorFactory` resolves the handler that was used to generate metadata

### DIFF
--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/CQRSObjectsRegistrationSource.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/CQRSObjectsRegistrationSource.cs
@@ -60,12 +60,14 @@ internal class CQRSObjectsRegistrationSource
 
     public void AddCQRSObject(CQRSObjectMetadata metadata)
     {
-        var added = objects.Add(metadata);
-
-        if (added)
+        if (!objects.Add(metadata))
         {
-            services.AddCQRSHandler(metadata);
+            throw new InvalidOperationException(
+                $"CQRS Object({metadata.ObjectKind}) {metadata.ObjectType} is already registered."
+            );
         }
+
+        services.AddCQRSHandler(metadata);
     }
 
     private static bool ValidateContractType(TypeInfo type)

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/ServiceCollectionRegistrationExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/ServiceCollectionRegistrationExtensions.cs
@@ -20,9 +20,8 @@ public static class ServiceCollectionRegistrationExtensions
 
     public static void AddCQRSHandler(this IServiceCollection serviceCollection, CQRSObjectMetadata obj)
     {
-        serviceCollection.Add(
-            new ServiceDescriptor(MakeHandlerInterfaceType(obj), obj.HandlerType, ServiceLifetime.Scoped)
-        );
+        serviceCollection.Add(new(MakeHandlerInterfaceType(obj), obj.HandlerType, ServiceLifetime.Scoped));
+        serviceCollection.Add(new(obj.HandlerType, obj.HandlerType, ServiceLifetime.Scoped));
 
         Type MakeHandlerInterfaceType(CQRSObjectMetadata obj)
         {

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/ServiceCollectionRegistrationExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Registration/ServiceCollectionRegistrationExtensions.cs
@@ -20,8 +20,10 @@ public static class ServiceCollectionRegistrationExtensions
 
     public static void AddCQRSHandler(this IServiceCollection serviceCollection, CQRSObjectMetadata obj)
     {
-        serviceCollection.Add(new(MakeHandlerInterfaceType(obj), obj.HandlerType, ServiceLifetime.Scoped));
         serviceCollection.Add(new(obj.HandlerType, obj.HandlerType, ServiceLifetime.Scoped));
+        serviceCollection.Add(
+            new(MakeHandlerInterfaceType(obj), sp => sp.GetRequiredService(obj.HandlerType), ServiceLifetime.Scoped)
+        );
 
         Type MakeHandlerInterfaceType(CQRSObjectMetadata obj)
         {

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/CQRSObjectsRegistrationSourceTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/CQRSObjectsRegistrationSourceTests.cs
@@ -49,7 +49,7 @@ public class CQRSObjectsRegistrationSourceTests
     }
 
     [Fact]
-    public void Same_objects_are_not_registered_multiple_times()
+    public void Duplicate_objects_cannot_be_registered()
     {
         var registrationSource = new CQRSObjectsRegistrationSource(services);
 
@@ -59,13 +59,12 @@ public class CQRSObjectsRegistrationSourceTests
         );
         var firstCount = registrationSource.Objects.Count;
 
-        registrationSource.AddCQRSObjects(
-            TypesCatalog.Of<CQRSObjectsRegistrationSourceTests>(),
-            TypesCatalog.Of<CQRSObjectsRegistrationSourceTests>()
-        );
-        var secondCount = registrationSource.Objects.Count;
-
-        firstCount.Should().Be(secondCount);
+        var act = () =>
+            registrationSource.AddCQRSObjects(
+                TypesCatalog.Of<CQRSObjectsRegistrationSourceTests>(),
+                TypesCatalog.Of<CQRSObjectsRegistrationSourceTests>()
+            );
+        act.Should().Throw<InvalidOperationException>();
     }
 
     private void AssertRegistered<TQuery, TResult, THandler>()


### PR DESCRIPTION
Previously, the `ObjectExecutorFactory` resolved `IXHandler<A>` directly from the container. The problem with that approach is that we can't be sure that the `TypeAssembly` that we get in `CQRSObjectsRegistrationSource.AddCQRSObjects` represents _all_ the assemblies that the user scanned for handlers when adding them to DI. For example, it is still possible to have this:

```
Contracts.csproj
   - Command : ICommand

HandlersA.csproj
  - CH1: ICommandHandler<Command>

HandlersB.csproj
  - CH2: ICommandHandler<Command>
```

Then in `App` have:
```
serviceCollection
    .AddCQRS(TypesAssembly.Of<Command>(), TypesAssembly.Of<CH1>())
    .AddCQRSObjects(TypesAssembly.Of<Command>(), TypesAssembly.Of<CH2>());
```

which would result, in the end, in (effectively, the code will be slightly different):
```
serviceCollection.AddTransient<ICommandHandler<Command>, CH1>();
serviceCollection.AddTransient<ICommandHandler<Command>, CH2>();
```

But the `CQRSObjectsRegistrationSource.objects` will have only the `Command, CH1` pair. Thus, the pipeline will _think_ that it executes `CH1`, but `CH2` will be resolved in `ObjectExecutorFactory.ExecuteCommandAsync`.

I admit that this is rather unlikely situation, but when it occurs, it might be very hard to detect. I also don't think this PR makes detection easier, but _at least_ it will resolve `CH1` when it thinks about `CH1`. This _might_ be more important for local execution though.