### PR TITLE
Bump MassTransit and fix missing method

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
     <ExtensionsVersion>8.0.0</ExtensionsVersion>
 
     <IdentityServerVersion>4.1.2</IdentityServerVersion>
-    <MassTransitVersion>8.1.3</MassTransitVersion>
+    <MassTransitVersion>8.2.4</MassTransitVersion>
     <SystemIdentityModelVersion>7.3.1</SystemIdentityModelVersion>
 
     <!-- Do not bump these dependencies if you don't want to force users to use newer .NET Core SDK -->

--- a/src/CQRS/LeanCode.CQRS.MassTransitRelay/MassTransitRegistrationConfigurationExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.MassTransitRelay/MassTransitRegistrationConfigurationExtensions.cs
@@ -30,7 +30,7 @@ public static class MassTransitRegistrationConfigurationExtensions
         Type defaultDefinition
     )
     {
-        var outer = types.Where(MessageTypeCache.HasConsumerInterfaces);
+        var outer = types.Where(RegistrationMetadata.IsConsumer);
         var inner = types.Where((Type x) => x.HasInterface(typeof(IConsumerDefinition<>)));
         var enumerable =
             from c in outer

--- a/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
+++ b/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
@@ -53,8 +53,7 @@ public class PostgresTestConfig : TestDatabaseConfig
 
     public override void ConfigureDbContext(DbContextOptionsBuilder builder, IConfiguration config)
     {
-        var dataSource = new NpgsqlDataSourceBuilder(config.GetValue<string>("Postgres:ConnectionString")).Build();
-        builder.UseNpgsql(dataSource).AddTimestampTzExpressionInterceptor();
+        builder.UseNpgsql(config.GetValue<string>("Postgres:ConnectionString")).AddTimestampTzExpressionInterceptor();
     }
 
     public override void ConfigureMassTransitOutbox(IEntityFrameworkOutboxConfigurator configurator)


### PR DESCRIPTION
`HasConsumerInterfaces` method got deleted :see_no_evil:
Using `IsConsumer` instead seems reasonable :smiley:  