### PR TITLE
Set `RawText` in `RoutePattern` when registering CQRS objects

### DIFF
--- a/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSEndpointsDataSource.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSEndpointsDataSource.cs
@@ -62,13 +62,14 @@ internal class CQRSEndpointsDataSource : EndpointDataSource
 
     private IEnumerable<(string Name, RoutePattern Pattern)> RoutesFor(CQRSObjectMetadata obj)
     {
-        var kindSegment = obj.ObjectKind switch
+        var kindString = obj.ObjectKind switch
         {
-            CQRSObjectKind.Command => RoutePatternFactory.Segment(RoutePatternFactory.LiteralPart("command")),
-            CQRSObjectKind.Query => RoutePatternFactory.Segment(RoutePatternFactory.LiteralPart("query")),
-            CQRSObjectKind.Operation => RoutePatternFactory.Segment(RoutePatternFactory.LiteralPart("operation")),
+            CQRSObjectKind.Command => "command",
+            CQRSObjectKind.Query => "query",
+            CQRSObjectKind.Operation => "operation",
             _ => throw new InvalidOperationException($"Unexpected object kind: {obj.ObjectKind}")
         };
+        var kindSegment = RoutePatternFactory.Segment(RoutePatternFactory.LiteralPart(kindString));
 
         var typeName = obj.ObjectType.FullName!;
 
@@ -82,7 +83,7 @@ internal class CQRSEndpointsDataSource : EndpointDataSource
         RoutePattern Path(string name)
         {
             var typeSegment = RoutePatternFactory.Segment(RoutePatternFactory.LiteralPart(name));
-            var path = RoutePatternFactory.Pattern(kindSegment, typeSegment);
+            var path = RoutePatternFactory.Pattern($"{kindString}/{name}", kindSegment, typeSegment);
             return RoutePatternFactory.Combine(basePath, path);
         }
     }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/CQRSEndpointsDataSourceTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/CQRSEndpointsDataSourceTests.cs
@@ -6,6 +6,7 @@ using LeanCode.CQRS.Execution;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -116,6 +117,8 @@ namespace LeanCode.CQRS.AspNetCore.Tests
             ctx.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
             var cqrsMetadata = ctx.GetCQRSObjectMetadata();
             cqrsMetadata.ObjectType.Should().Be(typeof(TObject));
+
+            ctx.GetEndpoint().Should().BeOfType<RouteEndpoint>().Subject.RoutePattern.RawText.Should().Be(path);
         }
 
         private async Task VerifyWrongPath(string path, string method = "POST", int statusCode = 404)


### PR DESCRIPTION
This metadata is used in a lot of places where the endpoint is displayed somehow, e.g. in traces.
With this change, all the tracing tooling instead of `POST /cqrs/` or `POST /api/` will display a
proper path.
