### PR TITLE
Migrate from legacy FCM APIs to HTTP v1

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -47,7 +47,7 @@
     <PackageReference Update="Microsoft.IdentityModel.Tokens" Version="$(SystemIdentityModelVersion)" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelVersion)" />
 
-    <PackageReference Update="FirebaseAdmin" Version="2.4.0" />
+    <PackageReference Update="FirebaseAdmin" Version="3.0.1" />
     <PackageReference Update="Google.Cloud.Firestore" Version="3.5.1" />
 
     <PackageReference Update="Microsoft.Data.SqlClient" Version="5.2.0" />

--- a/src/Infrastructure/LeanCode.Firebase.FCM/FCMClient.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/FCMClient.cs
@@ -72,7 +72,7 @@ public class FCMClient<TUserId>
                 userId,
                 message.Tokens.Count
             );
-            var response = await messaging.SendMulticastAsync(message, dryRun, cancellationToken);
+            var response = await messaging.SendEachForMulticastAsync(message, dryRun, cancellationToken);
             await HandleBatchResponseAsync(response, message.Tokens, cancellationToken);
         }
     }
@@ -98,7 +98,7 @@ public class FCMClient<TUserId>
                 userIds.Count,
                 message.Tokens.Count
             );
-            var response = await messaging.SendMulticastAsync(message, dryRun, cancellationToken);
+            var response = await messaging.SendEachForMulticastAsync(message, dryRun, cancellationToken);
             await HandleBatchResponseAsync(response, message.Tokens, cancellationToken);
         }
     }
@@ -111,7 +111,7 @@ public class FCMClient<TUserId>
     {
         logger.Debug("Sending {Count} push messages", messages.Count());
 
-        var response = await messaging.SendAllAsync(messages, dryRun, cancellationToken);
+        var response = await messaging.SendEachAsync(messages, dryRun, cancellationToken);
         await HandleBatchResponseAsync(response, messages.Select(m => m.Token), cancellationToken);
     }
 
@@ -123,7 +123,7 @@ public class FCMClient<TUserId>
     {
         logger.Debug("Sending multicast push message to {Count} targets", message.Tokens.Count);
 
-        var response = await messaging.SendMulticastAsync(message, dryRun, cancellationToken);
+        var response = await messaging.SendEachForMulticastAsync(message, dryRun, cancellationToken);
         await HandleBatchResponseAsync(response, message.Tokens, cancellationToken);
     }
 


### PR DESCRIPTION
According to [FCM docs](https://firebase.google.com/docs/cloud-messaging/migrate-v1) the legacy APIs for sending messages were retired on July 22, 2024.

I found in [Firebase FAQ page](https://firebase.google.com/support/faq?hl=en#fcm-depr-admin), that the new API was indeed introduced with [2.4.0](https://github.com/firebase/firebase-admin-dotnet/releases/tag/v2.4.0) version of FirebaseAdmin, but the legacy methods were not deprecated (and we continued to use them). They were deprecated in [2.4.1](https://github.com/firebase/firebase-admin-dotnet/releases/tag/v2.4.1).