### PR TITLE
Do not embed LICENSE file in NuGets

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionDir)LICENSE"  Pack="true" />
     <ProjectReference Include="../../Tools/LeanCode.CodeAnalysis/LeanCode.CodeAnalysis.csproj"
                       Condition="'$(MSBuildProjectName)' != 'LeanCode.CodeAnalysis'
                                 And '$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
This is redundant. We use SPDX-compliant license (w/o changes), thus we can rely solely on `PackageLicenseExpression`.
