### PR TITLE
Allow setting custom type formatters in FCM notifications

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,19 +7,19 @@ insert_final_newline = true
 indent_style = space
 trim_trailing_whitespace = true
 
-[*.{ts, tsx, js}]
+[*.{ts,tsx,js}]
 indent_size = 4
 
-[*.{less, sass, scss}]
+[*.{less,sass,scss}]
 indent_size = 4
 
-[*.{json, yml}]
+[*.{json,yml}]
 indent_size = 2
 
-[*.{xml, targets, csproj, props}]
+[*.{xml,targets,csproj,props}]
 indent_size = 2
 
-[*.{cshtml, cstxt}]
+[*.{cshtml,cstxt}]
 insert_final_newline = false
 
 [*.{cs}]

--- a/src/Infrastructure/LeanCode.Firebase.FCM/NotificationDataConverter.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/NotificationDataConverter.cs
@@ -1,0 +1,58 @@
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace LeanCode.Firebase.FCM;
+
+public sealed class NotificationDataConverter
+{
+    private const string TypeField = "Type";
+
+    private ImmutableDictionary<Type, Func<object, string>> formatters = ImmutableDictionary<
+        Type,
+        Func<object, string>
+    >.Empty;
+
+    public void FormatUsing<T>(Func<T, string> formatter)
+    {
+        formatters = formatters.Add(typeof(T), o => formatter((T)o));
+    }
+
+    /// <summary>
+    /// Converts POCO object to a notification data dictionary. Does not support hierarchical
+    /// data.
+    /// </summary>
+    public Dictionary<string, string> ToNotificationData(object data)
+    {
+        var type = data.GetType();
+
+        var result = new Dictionary<string, string>() { [TypeField] = type.Name, };
+
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.Name != TypeField)
+            {
+                var value = prop.GetValue(data);
+
+                if (value is not null)
+                {
+                    var formatter = formatters.GetValueOrDefault(value.GetType(), DefaultValueFormatter);
+                    result.Add(prop.Name, formatter(value));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static string DefaultValueFormatter(object value)
+    {
+        if (value is Enum @enum)
+        {
+            return @enum.ToString("D");
+        }
+        else
+        {
+            return value.ToString()!;
+        }
+    }
+}

--- a/src/Infrastructure/LeanCode.Firebase.FCM/NotificationDataConverter.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/NotificationDataConverter.cs
@@ -1,20 +1,16 @@
-using System.Collections.Immutable;
+using System.Collections.Frozen;
 using System.Reflection;
 
 namespace LeanCode.Firebase.FCM;
 
 public sealed class NotificationDataConverter
 {
+    private readonly FrozenDictionary<Type, Func<object, string>> formatters;
     private const string TypeField = "Type";
 
-    private ImmutableDictionary<Type, Func<object, string>> formatters = ImmutableDictionary<
-        Type,
-        Func<object, string>
-    >.Empty;
-
-    public void FormatUsing<T>(Func<T, string> formatter)
+    private NotificationDataConverter(FrozenDictionary<Type, Func<object, string>> formatters)
     {
-        formatters = formatters.Add(typeof(T), o => formatter((T)o));
+        this.formatters = formatters;
     }
 
     /// <summary>
@@ -35,13 +31,21 @@ public sealed class NotificationDataConverter
 
                 if (value is not null)
                 {
-                    var formatter = formatters.GetValueOrDefault(value.GetType(), DefaultValueFormatter);
+                    var formatter = formatters.GetValueOrDefault(GetEffectiveType(value), DefaultValueFormatter);
                     result.Add(prop.Name, formatter(value));
                 }
             }
         }
 
         return result;
+    }
+
+    public static Builder New() => new();
+
+    private static Type GetEffectiveType(object value)
+    {
+        var type = value.GetType();
+        return Nullable.GetUnderlyingType(value.GetType()) ?? type;
     }
 
     private static string DefaultValueFormatter(object value)
@@ -54,5 +58,21 @@ public sealed class NotificationDataConverter
         {
             return value.ToString()!;
         }
+    }
+
+    public class Builder
+    {
+        private readonly Dictionary<Type, Func<object, string>> formatters = new();
+
+        internal Builder() { }
+
+        public Builder AddFormatter<T>(Func<T, string> formatter)
+            where T : notnull
+        {
+            formatters.Add(typeof(T), o => formatter((T)o));
+            return this;
+        }
+
+        public NotificationDataConverter Build() => new(formatters.ToFrozenDictionary());
     }
 }

--- a/src/Infrastructure/LeanCode.Firebase.FCM/Notifications.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/Notifications.cs
@@ -1,11 +1,20 @@
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Reflection;
 
 namespace LeanCode.Firebase.FCM;
 
 public static class Notifications
 {
+    private static ImmutableDictionary<Type, Func<object, string>> formatters = ImmutableDictionary<
+        Type,
+        Func<object, string>
+    >.Empty;
+
+    public static void FormatUsing<T>(Func<T, string> formatter)
+    {
+        formatters = formatters.Add(typeof(T), o => formatter((T)o));
+    }
+
     private const string TypeField = "Type";
 
     /// <summary>
@@ -26,21 +35,24 @@ public static class Notifications
 
                 if (value is not null)
                 {
-                    if (value is Enum @enum)
-                    {
-                        var strValue = Convert
-                            .ToInt32(@enum, System.Globalization.CultureInfo.InvariantCulture)
-                            .ToString(System.Globalization.CultureInfo.InvariantCulture);
-                        result.Add(prop.Name, strValue);
-                    }
-                    else
-                    {
-                        result.Add(prop.Name, value.ToString()!);
-                    }
+                    var formatter = formatters.GetValueOrDefault(value.GetType(), DefaultValueFormatter);
+                    result.Add(prop.Name, formatter(value));
                 }
             }
         }
 
         return result;
+    }
+
+    private static string DefaultValueFormatter(object value)
+    {
+        if (value is Enum @enum)
+        {
+            return @enum.ToString("D");
+        }
+        else
+        {
+            return value.ToString()!;
+        }
     }
 }

--- a/src/Infrastructure/LeanCode.Firebase.FCM/Notifications.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/Notifications.cs
@@ -1,58 +1,16 @@
-using System.Collections.Immutable;
-using System.Reflection;
-
 namespace LeanCode.Firebase.FCM;
 
 public static class Notifications
 {
-    private static ImmutableDictionary<Type, Func<object, string>> formatters = ImmutableDictionary<
-        Type,
-        Func<object, string>
-    >.Empty;
-
-    public static void FormatUsing<T>(Func<T, string> formatter)
-    {
-        formatters = formatters.Add(typeof(T), o => formatter((T)o));
-    }
-
-    private const string TypeField = "Type";
+    private static readonly NotificationDataConverter SharedConverter = new();
 
     /// <summary>
     /// Converts POCO object to a notification data dictionary. Does not support hierarchical
     /// data.
     /// </summary>
+    [Obsolete("Use `NotificationDataConverter.ToNotificationData` instead` ")]
     public static Dictionary<string, string> ToNotificationData(object data)
     {
-        var type = data.GetType();
-
-        var result = new Dictionary<string, string>() { [TypeField] = type.Name, };
-
-        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-        {
-            if (prop.Name != TypeField)
-            {
-                var value = prop.GetValue(data);
-
-                if (value is not null)
-                {
-                    var formatter = formatters.GetValueOrDefault(value.GetType(), DefaultValueFormatter);
-                    result.Add(prop.Name, formatter(value));
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private static string DefaultValueFormatter(object value)
-    {
-        if (value is Enum @enum)
-        {
-            return @enum.ToString("D");
-        }
-        else
-        {
-            return value.ToString()!;
-        }
+        return SharedConverter.ToNotificationData(data);
     }
 }

--- a/src/Infrastructure/LeanCode.Firebase.FCM/Notifications.cs
+++ b/src/Infrastructure/LeanCode.Firebase.FCM/Notifications.cs
@@ -2,7 +2,7 @@ namespace LeanCode.Firebase.FCM;
 
 public static class Notifications
 {
-    private static readonly NotificationDataConverter SharedConverter = new();
+    private static readonly NotificationDataConverter SharedConverter = NotificationDataConverter.New().Build();
 
     /// <summary>
     /// Converts POCO object to a notification data dictionary. Does not support hierarchical

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/FCMClientTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/FCMClientTests.cs
@@ -7,8 +7,8 @@ namespace LeanCode.Firebase.FCM.Tests;
 
 public class FCMClientTests
 {
-    public static readonly string Key = Environment.GetEnvironmentVariable("FCM_KEY");
-    public static readonly string Token = Environment.GetEnvironmentVariable("FCM_TOKEN");
+    public static readonly string Key = Environment.GetEnvironmentVariable("FCM_KEY")!; // Nullability handled via [FCMFact]
+    public static readonly string Token = Environment.GetEnvironmentVariable("FCM_TOKEN")!;
 
     private static readonly Guid UserId = Guid.NewGuid();
 

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/LeanCode.Firebase.FCM.Tests.csproj
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/LeanCode.Firebase.FCM.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../../src/Infrastructure/LeanCode.Firebase.FCM/LeanCode.Firebase.FCM.csproj" />

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/LeanCode.Firebase.FCM.Tests.csproj
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/LeanCode.Firebase.FCM.Tests.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="../../../src/Infrastructure/LeanCode.Firebase.FCM/LeanCode.Firebase.FCM.csproj" />
   </ItemGroup>

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/NotificationConversionTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/NotificationConversionTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using FluentAssertions;
 using Xunit;
 
 namespace LeanCode.Firebase.FCM.Tests;
@@ -11,7 +13,7 @@ public class NotificationConversionTests
     {
         var data = Notifications.ToNotificationData(new { Field = IntEnum.Second });
 
-        Assert.Equal("1", data["Field"]);
+        data.Should().ContainKey("Field").WhoseValue.Should().Be("1");
     }
 
     [Fact]
@@ -19,7 +21,18 @@ public class NotificationConversionTests
     {
         var data = Notifications.ToNotificationData(new { Field = ByteEnum.Second });
 
-        Assert.Equal("1", data["Field"]);
+        data.Should().ContainKey("Field").WhoseValue.Should().Be("1");
+    }
+
+    [Fact]
+    public void Applies_custom_value_formatters()
+    {
+        Notifications.FormatUsing<DateTimeOffset>(d => d.ToString("O", CultureInfo.InvariantCulture));
+
+        var date = new DateTimeOffset(2024, 9, 25, 13, 56, 48, TimeSpan.FromHours(2));
+        var data = Notifications.ToNotificationData(new { Date = date });
+
+        data.Should().ContainKey("Date").WhoseValue.Should().Be("2024-09-25T13:56:48.0000000+02:00");
     }
 
     private enum IntEnum

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/NotificationConversionTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/NotificationConversionTests.cs
@@ -6,13 +6,10 @@ namespace LeanCode.Firebase.FCM.Tests;
 
 public class NotificationConversionTests
 {
-    private readonly NotificationDataConverter converter;
-
-    public NotificationConversionTests()
-    {
-        converter = new();
-        converter.FormatUsing<DateTimeOffset>(d => d.ToString("O", CultureInfo.InvariantCulture));
-    }
+    private readonly NotificationDataConverter converter = NotificationDataConverter
+        .New()
+        .AddFormatter<DateTimeOffset>(d => d.ToString("O", CultureInfo.InvariantCulture))
+        .Build();
 
     [Fact]
     public void Converts_int_enum_correctly()
@@ -35,6 +32,15 @@ public class NotificationConversionTests
     {
         var date = new DateTimeOffset(2024, 9, 25, 13, 56, 48, TimeSpan.FromHours(2));
         var data = converter.ToNotificationData(new { Date = date });
+
+        data.Should().ContainKey("Date").WhoseValue.Should().Be("2024-09-25T13:56:48.0000000+02:00");
+    }
+
+    [Fact]
+    public void Applies_custom_value_formatters_for_nullable_types()
+    {
+        var date = new DateTimeOffset(2024, 9, 25, 13, 56, 48, TimeSpan.FromHours(2));
+        var data = converter.ToNotificationData(new { Date = (DateTimeOffset?)date });
 
         data.Should().ContainKey("Date").WhoseValue.Should().Be("2024-09-25T13:56:48.0000000+02:00");
     }

--- a/test/Infrastructure/LeanCode.Firebase.FCM.Tests/NotificationConversionTests.cs
+++ b/test/Infrastructure/LeanCode.Firebase.FCM.Tests/NotificationConversionTests.cs
@@ -6,12 +6,18 @@ namespace LeanCode.Firebase.FCM.Tests;
 
 public class NotificationConversionTests
 {
-    public NotificationConversionTests() { }
+    private readonly NotificationDataConverter converter;
+
+    public NotificationConversionTests()
+    {
+        converter = new();
+        converter.FormatUsing<DateTimeOffset>(d => d.ToString("O", CultureInfo.InvariantCulture));
+    }
 
     [Fact]
     public void Converts_int_enum_correctly()
     {
-        var data = Notifications.ToNotificationData(new { Field = IntEnum.Second });
+        var data = converter.ToNotificationData(new { Field = IntEnum.Second });
 
         data.Should().ContainKey("Field").WhoseValue.Should().Be("1");
     }
@@ -19,7 +25,7 @@ public class NotificationConversionTests
     [Fact]
     public void Converts_byte_enum_correctly()
     {
-        var data = Notifications.ToNotificationData(new { Field = ByteEnum.Second });
+        var data = converter.ToNotificationData(new { Field = ByteEnum.Second });
 
         data.Should().ContainKey("Field").WhoseValue.Should().Be("1");
     }
@@ -27,10 +33,8 @@ public class NotificationConversionTests
     [Fact]
     public void Applies_custom_value_formatters()
     {
-        Notifications.FormatUsing<DateTimeOffset>(d => d.ToString("O", CultureInfo.InvariantCulture));
-
         var date = new DateTimeOffset(2024, 9, 25, 13, 56, 48, TimeSpan.FromHours(2));
-        var data = Notifications.ToNotificationData(new { Date = date });
+        var data = converter.ToNotificationData(new { Date = date });
 
         data.Should().ContainKey("Date").WhoseValue.Should().Be("2024-09-25T13:56:48.0000000+02:00");
     }


### PR DESCRIPTION
Just a proposal to fix #662. Clients are able to override how types are serialized. 

I didn't provide any defaults, especially for dates as it might be a breaking change for the apps 