### PR TITLE
Share `JsonOptions` with the wider ASP.NET Core ecosystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ but this project DOES NOT adhere to [Semantic Versioning](http://semver.org/).
 * Remove LeanCode.ExternalIdentityProviders
 * Remove LeanCode.PdfRocket
 * Remove StyleCop completely
+* JSON serializer for CQRS now shares options with ASP.NET Core's `JsonOptions` by default
 
 ## 8.1
 

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Serialization/ISerializer.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Serialization/ISerializer.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using LeanCode.Serialization;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
 
 namespace LeanCode.CQRS.AspNetCore.Serialization;
 
@@ -9,35 +11,26 @@ public interface ISerializer
     ValueTask<object?> DeserializeAsync(Stream utf8Json, Type returnType, CancellationToken cancellationToken);
 }
 
-public sealed class Utf8JsonSerializer : ISerializer
+public sealed class Utf8JsonSerializer(IOptions<JsonOptions> options) : ISerializer
 {
-    public static readonly JsonSerializerOptions DefaultOptions = new()
-    {
-        Converters =
-        {
-            new JsonLaxDateOnlyConverter(),
-            new JsonLaxTimeOnlyConverter(),
-            new JsonLaxDateTimeOffsetConverter(),
-        },
-    };
-
-    private readonly JsonSerializerOptions? options;
-
-    public Utf8JsonSerializer(JsonSerializerOptions? options)
-    {
-        this.options = options;
-    }
-
-    public Utf8JsonSerializer()
-        : this(null) { }
-
     public ValueTask<object?> DeserializeAsync(Stream utf8Json, Type returnType, CancellationToken cancellationToken)
     {
-        return JsonSerializer.DeserializeAsync(utf8Json, returnType, options, cancellationToken);
+        return JsonSerializer.DeserializeAsync(
+            utf8Json,
+            returnType,
+            options.Value.SerializerOptions,
+            cancellationToken
+        );
     }
 
     public Task SerializeAsync(Stream utf8Json, object value, Type inputType, CancellationToken cancellationToken)
     {
-        return JsonSerializer.SerializeAsync(utf8Json, value, inputType, options, cancellationToken);
+        return JsonSerializer.SerializeAsync(
+            utf8Json,
+            value,
+            inputType,
+            options.Value.SerializerOptions,
+            cancellationToken
+        );
     }
 }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs
@@ -6,10 +6,12 @@ using LeanCode.CQRS.AspNetCore.Serialization;
 using LeanCode.CQRS.Execution;
 using LeanCode.CQRS.Security;
 using LeanCode.CQRS.Validation;
+using LeanCode.Serialization;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace LeanCode.CQRS.AspNetCore;
 
@@ -18,10 +20,22 @@ public static class ServiceCollectionCQRSExtensions
     public static CQRSServicesBuilder AddCQRS(
         this IServiceCollection serviceCollection,
         TypesCatalog contractsCatalog,
-        TypesCatalog handlersCatalog
+        TypesCatalog handlersCatalog,
+        bool configureJsonOptions = true
     )
     {
-        serviceCollection.AddSingleton<ISerializer>(_ => new Utf8JsonSerializer(Utf8JsonSerializer.DefaultOptions));
+        if (configureJsonOptions)
+        {
+            serviceCollection.ConfigureHttpJsonOptions(options =>
+            {
+                options.SerializerOptions.Converters.Add(new JsonLaxDateOnlyConverter());
+                options.SerializerOptions.Converters.Add(new JsonLaxTimeOnlyConverter());
+                options.SerializerOptions.Converters.Add(new JsonLaxDateTimeOffsetConverter());
+                options.SerializerOptions.PropertyNamingPolicy = null;
+            });
+        }
+
+        serviceCollection.AddSingleton<ISerializer, Utf8JsonSerializer>();
 
         var objectsSource = new CQRSObjectsRegistrationSource(serviceCollection, new ObjectExecutorFactory());
         objectsSource.AddCQRSObjects(contractsCatalog, handlersCatalog);


### PR DESCRIPTION
The default `ISerializer` for CQRS now uses `JsonOptions`. This is required to make it cooperate
with ASP.NET Core better (e.g. OpenAPI generation).
