### PR TITLE
Allow specifying content type in ISerializer

### DIFF
--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
@@ -88,7 +88,7 @@ public class CQRSMiddleware
 
         if (result.HasPayload)
         {
-            httpContext.Response.ContentType = "application/json";
+            httpContext.Response.ContentType = serializer.ContentType;
             if (result.Payload is null)
             {
                 await httpContext.Response.Body.WriteAsync(NullString);

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Serialization/ISerializer.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Serialization/ISerializer.cs
@@ -7,12 +7,15 @@ namespace LeanCode.CQRS.AspNetCore.Serialization;
 
 public interface ISerializer
 {
+    string ContentType { get; }
     Task SerializeAsync(Stream utf8Json, object value, Type inputType, CancellationToken cancellationToken);
     ValueTask<object?> DeserializeAsync(Stream utf8Json, Type returnType, CancellationToken cancellationToken);
 }
 
 public sealed class Utf8JsonSerializer(IOptions<JsonOptions> options) : ISerializer
 {
+    public string ContentType => "application/json; charset=utf-8";
+
     public ValueTask<object?> DeserializeAsync(Stream utf8Json, Type returnType, CancellationToken cancellationToken)
     {
         return JsonSerializer.DeserializeAsync(

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTests.cs
@@ -27,6 +27,7 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
 
     protected override void ConfigureServices(IServiceCollection services)
     {
+        serializer.ContentType.Returns("application/json");
         services.AddSingleton(_ => serializer);
     }
 

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/ServiceProviderRegistrationExtensionsTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/ServiceProviderRegistrationExtensionsTests.cs
@@ -95,6 +95,8 @@ public class ServiceProviderRegistrationExtensionsTests
 
     internal sealed class CustomSerializer : ISerializer
     {
+        public string ContentType => throw new NotImplementedException();
+
         public ValueTask<object?> DeserializeAsync(
             Stream utf8Json,
             Type returnType,


### PR DESCRIPTION
Also, makes sure charset is returned. Otherwise mobile might not work as expected.
