### PR TITLE
Open trace on periodic execution

### DIFF
--- a/src/Infrastructure/LeanCode.PeriodicService/LeanCode.PeriodicService.csproj
+++ b/src/Infrastructure/LeanCode.PeriodicService/LeanCode.PeriodicService.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <ProjectReference Include="../LeanCode.OpenTelemetry/LeanCode.OpenTelemetry.csproj" />
     <ProjectReference Include="../../Domain/LeanCode.TimeProvider/LeanCode.TimeProvider.csproj" />
 
     <PackageReference Include="Cronos" />

--- a/src/Infrastructure/LeanCode.PeriodicService/PeriodicHostedService.cs
+++ b/src/Infrastructure/LeanCode.PeriodicService/PeriodicHostedService.cs
@@ -1,3 +1,4 @@
+using LeanCode.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -41,6 +42,7 @@ public class PeriodicHostedService<TAction> : BackgroundService
     )]
     private async Task<TimeSpan> ExecuteOnceAsync(int executionNo, CancellationToken stoppingToken)
     {
+        using var activity = LeanCodeActivitySource.Start($"periodic action - {typeof(TAction).Name}");
         await using var scope = serviceProvider.CreateAsyncScope();
         var service = scope.ServiceProvider.GetRequiredService<TAction>();
         if (!service.SkipFirstExecution || executionNo > 0)
@@ -51,6 +53,7 @@ public class PeriodicHostedService<TAction> : BackgroundService
             }
             catch (Exception ex)
             {
+                activity?.AddException(ex);
                 logger.Error(ex, "Cannot run periodic action, exception has been thrown");
             }
         }

--- a/src/Infrastructure/LeanCode.PeriodicService/PeriodicHostedService.cs
+++ b/src/Infrastructure/LeanCode.PeriodicService/PeriodicHostedService.cs
@@ -42,7 +42,7 @@ public class PeriodicHostedService<TAction> : BackgroundService
     )]
     private async Task<TimeSpan> ExecuteOnceAsync(int executionNo, CancellationToken stoppingToken)
     {
-        using var activity = LeanCodeActivitySource.Start($"periodic action - {typeof(TAction).Name}");
+        using var activity = LeanCodeActivitySource.StartExecution("periodic action", typeof(TAction).Name);
         await using var scope = serviceProvider.CreateAsyncScope();
         var service = scope.ServiceProvider.GetRequiredService<TAction>();
         if (!service.SkipFirstExecution || executionNo > 0)


### PR DESCRIPTION
Not sure if we want to use the same `ActivitySource`. It seems like it was implicitly only for CQRS (even though nothing explicitly suggests it). We could have dedicated activity sources for various packages and have `AddLeanCodeTelemetry(...)` register all `"LeanCode.CoreLibrary"` and `"LeanCode.CoreLibrary.*"` activities.

Aaalso `AddLeanCodeTelemetry()` and `AddLeanCodeMetrics()` names are kind of outside of the norm (both should be `AddLeanCodeInstrumentation`) 