### PR TITLE
Always return constructed type from `VersionSupportQH`

### DIFF
--- a/src/Infrastructure/LeanCode.ForceUpdate/LeanCode.ForceUpdate.Services/CQRS/VersionSupportQH.cs
+++ b/src/Infrastructure/LeanCode.ForceUpdate/LeanCode.ForceUpdate.Services/CQRS/VersionSupportQH.cs
@@ -5,7 +5,7 @@ using VersionSupport = LeanCode.ForceUpdate.Contracts.VersionSupport;
 
 namespace LeanCode.ForceUpdate.Services.CQRS;
 
-public class VersionSupportQH : IQueryHandler<VersionSupport, VersionSupportDTO?>
+public class VersionSupportQH : IQueryHandler<VersionSupport, VersionSupportDTO>
 {
     private readonly Serilog.ILogger logger = Serilog.Log.ForContext<VersionSupportQH>();
 
@@ -24,22 +24,29 @@ public class VersionSupportQH : IQueryHandler<VersionSupport, VersionSupportDTO?
         this.versionHandler = versionHandler;
     }
 
-    public async Task<VersionSupportDTO?> ExecuteAsync(HttpContext context, VersionSupport query)
+    public async Task<VersionSupportDTO> ExecuteAsync(HttpContext context, VersionSupport query)
     {
+        var (minimum, current) = GetVersions(query.Platform);
+
         if (!Version.TryParse(query.Version, out var version) || !Enum.IsDefined(query.Platform))
         {
             logger.Warning("Invalid input: {Version}, {Platform}", query.Version, query.Platform);
-            return null;
+            return new VersionSupportDTO
+            {
+                CurrentlySupportedVersion = current.ToString(),
+                MinimumRequiredVersion = minimum.ToString(),
+                Result = VersionSupportResultDTO.UpToDate,
+            };
         }
-
-        var (minimum, current) = GetVersions(query.Platform);
-
-        return new VersionSupportDTO
+        else
         {
-            CurrentlySupportedVersion = current.ToString(),
-            MinimumRequiredVersion = minimum.ToString(),
-            Result = await versionHandler.CheckVersionAsync(version, query.Platform, context),
-        };
+            return new VersionSupportDTO
+            {
+                CurrentlySupportedVersion = current.ToString(),
+                MinimumRequiredVersion = minimum.ToString(),
+                Result = await versionHandler.CheckVersionAsync(version, query.Platform, context),
+            };
+        }
     }
 
     private (Version Minimum, Version Current) GetVersions(PlatformDTO platform)

--- a/src/Infrastructure/LeanCode.ForceUpdate/LeanCode.ForceUpdate.Services/CQRS/VersionSupportQH.cs
+++ b/src/Infrastructure/LeanCode.ForceUpdate/LeanCode.ForceUpdate.Services/CQRS/VersionSupportQH.cs
@@ -26,20 +26,19 @@ public class VersionSupportQH : IQueryHandler<VersionSupport, VersionSupportDTO>
 
     public async Task<VersionSupportDTO> ExecuteAsync(HttpContext context, VersionSupport query)
     {
-        var (minimum, current) = GetVersions(query.Platform);
-
         if (!Version.TryParse(query.Version, out var version) || !Enum.IsDefined(query.Platform))
         {
             logger.Warning("Invalid input: {Version}, {Platform}", query.Version, query.Platform);
             return new VersionSupportDTO
             {
-                CurrentlySupportedVersion = current.ToString(),
-                MinimumRequiredVersion = minimum.ToString(),
+                CurrentlySupportedVersion = "0.0.0",
+                MinimumRequiredVersion = "0.0.0",
                 Result = VersionSupportResultDTO.UpToDate,
             };
         }
         else
         {
+            var (minimum, current) = GetVersions(query.Platform);
             return new VersionSupportDTO
             {
                 CurrentlySupportedVersion = current.ToString(),

--- a/test/Infrastructure/LeanCode.ForceUpdate.Tests/ForceUpdateTests.cs
+++ b/test/Infrastructure/LeanCode.ForceUpdate.Tests/ForceUpdateTests.cs
@@ -17,6 +17,7 @@ public class ForceUpdateTests
     private const string IOSCurrentlySupportedVersion = "1.3";
 
     private readonly ServiceProvider serviceProvider;
+    private readonly IQueryHandler<VersionSupport, VersionSupportDTO> handler;
 
     public ForceUpdateTests()
     {
@@ -34,13 +35,13 @@ public class ForceUpdateTests
                 )
             );
 
-        this.serviceProvider = services.BuildServiceProvider();
+        serviceProvider = services.BuildServiceProvider();
+        handler = serviceProvider.GetRequiredService<IQueryHandler<VersionSupport, VersionSupportDTO>>();
     }
 
     [Fact]
     public async Task Version_smaller_then_minimum_required_is_not_supported()
     {
-        var handler = serviceProvider.GetRequiredService<IQueryHandler<VersionSupport, VersionSupportDTO?>>();
         var result = await handler.ExecuteAsync(
             new DefaultHttpContext(),
             new VersionSupport { Platform = PlatformDTO.IOS, Version = "0.9" }
@@ -61,7 +62,6 @@ public class ForceUpdateTests
     [Fact]
     public async Task Update_is_suggested_for_version_between_minium_and_current()
     {
-        var handler = serviceProvider.GetRequiredService<IQueryHandler<VersionSupport, VersionSupportDTO?>>();
         var result = await handler.ExecuteAsync(
             new DefaultHttpContext(),
             new VersionSupport { Platform = PlatformDTO.Android, Version = "2.2" }
@@ -82,7 +82,6 @@ public class ForceUpdateTests
     [Fact]
     public async Task Version_above_currently_supported_is_up_to_date()
     {
-        var handler = serviceProvider.GetRequiredService<IQueryHandler<VersionSupport, VersionSupportDTO?>>();
         var result = await handler.ExecuteAsync(
             new DefaultHttpContext(),
             new VersionSupport { Platform = PlatformDTO.IOS, Version = "1.4" }
@@ -101,12 +100,33 @@ public class ForceUpdateTests
     }
 
     [Fact]
-    public async Task Version_support_returns_up_to_date_result_for_invalid_version()
+    public async Task Returns_up_to_date_result_for_invalid_version()
     {
-        var handler = serviceProvider.GetRequiredService<IQueryHandler<VersionSupport, VersionSupportDTO?>>();
         var result = await handler.ExecuteAsync(
             new DefaultHttpContext(),
             new VersionSupport { Platform = PlatformDTO.IOS, Version = "1.x" }
+        );
+
+        result.Should().BeEquivalentTo(new { Result = VersionSupportResultDTO.UpToDate });
+    }
+
+    [Fact]
+    public async Task Returns_zero_version_if_platform_cannot_be_deduced()
+    {
+        var result = await handler.ExecuteAsync(
+            new DefaultHttpContext(),
+            new VersionSupport { Platform = (PlatformDTO)100, Version = "1.0" }
+        );
+
+        result.Should().BeEquivalentTo(new { CurrentlySupportedVersion = "0.0.0", MinimumRequiredVersion = "0.0.0" });
+    }
+
+    [Fact]
+    public async Task If_both_version_and_platform_are_invalid_returns_UpToDate_response_with_fake_version()
+    {
+        var result = await handler.ExecuteAsync(
+            new DefaultHttpContext(),
+            new VersionSupport { Platform = (PlatformDTO)100, Version = "1.x" }
         );
 
         result
@@ -114,8 +134,8 @@ public class ForceUpdateTests
             .BeEquivalentTo(
                 new VersionSupportDTO
                 {
-                    CurrentlySupportedVersion = IOSCurrentlySupportedVersion,
-                    MinimumRequiredVersion = IOSMinimumRequiredVersion,
+                    CurrentlySupportedVersion = "0.0.0",
+                    MinimumRequiredVersion = "0.0.0",
                     Result = VersionSupportResultDTO.UpToDate,
                 }
             );

--- a/test/Infrastructure/LeanCode.ForceUpdate.Tests/ForceUpdateTests.cs
+++ b/test/Infrastructure/LeanCode.ForceUpdate.Tests/ForceUpdateTests.cs
@@ -101,7 +101,7 @@ public class ForceUpdateTests
     }
 
     [Fact]
-    public async Task Version_support_returns_null_for_invalid_version()
+    public async Task Version_support_returns_up_to_date_result_for_invalid_version()
     {
         var handler = serviceProvider.GetRequiredService<IQueryHandler<VersionSupport, VersionSupportDTO?>>();
         var result = await handler.ExecuteAsync(
@@ -109,6 +109,15 @@ public class ForceUpdateTests
             new VersionSupport { Platform = PlatformDTO.IOS, Version = "1.x" }
         );
 
-        result.Should().BeNull();
+        result
+            .Should()
+            .BeEquivalentTo(
+                new VersionSupportDTO
+                {
+                    CurrentlySupportedVersion = IOSCurrentlySupportedVersion,
+                    MinimumRequiredVersion = IOSMinimumRequiredVersion,
+                    Result = VersionSupportResultDTO.UpToDate,
+                }
+            );
     }
 }

--- a/test/Infrastructure/LeanCode.ForceUpdate.Tests/ForceUpdateTests.cs
+++ b/test/Infrastructure/LeanCode.ForceUpdate.Tests/ForceUpdateTests.cs
@@ -40,7 +40,7 @@ public class ForceUpdateTests
     }
 
     [Fact]
-    public async Task Version_smaller_then_minimum_required_is_not_supported()
+    public async Task Version_smaller_than_minimum_required_is_not_supported()
     {
         var result = await handler.ExecuteAsync(
             new DefaultHttpContext(),
@@ -60,7 +60,7 @@ public class ForceUpdateTests
     }
 
     [Fact]
-    public async Task Update_is_suggested_for_version_between_minium_and_current()
+    public async Task Update_is_suggested_for_version_between_minimum_and_current()
     {
         var result = await handler.ExecuteAsync(
             new DefaultHttpContext(),


### PR DESCRIPTION
The query should never return null (as it is stated in contracts), thus let's assume that the wrong version is "always newer".