### PR TITLE
Allow specifying literal subjects in SendGridLocalizedRazorMessage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -117,6 +117,7 @@
 
   <ItemGroup>
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/src/Infrastructure/LeanCode.SendGrid/SendGridLocalizedRazorMessage.cs
+++ b/src/Infrastructure/LeanCode.SendGrid/SendGridLocalizedRazorMessage.cs
@@ -9,6 +9,9 @@ public class SendGridLocalizedRazorMessage : SendGridRazorMessage
     internal CultureInfo Culture { get; private set; }
 
     [JsonIgnore]
+    public string? LocalizedSubjectKey { get; set; }
+
+    [JsonIgnore]
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "?",
         "CA1819",
@@ -26,10 +29,9 @@ public class SendGridLocalizedRazorMessage : SendGridRazorMessage
         Culture = cultureInfo.IsReadOnly ? cultureInfo : CultureInfo.ReadOnly(cultureInfo);
     }
 
-    public void SetGlobalSubject(string subjectKey, object[]? subjectFormatArgs)
+    public void SetLocalizedSubject(string subjectKey, object[]? subjectFormatArgs)
     {
-        SetGlobalSubject(subjectKey);
-
+        LocalizedSubjectKey = subjectKey;
         SubjectFormatArgs = subjectFormatArgs;
     }
 

--- a/src/Infrastructure/LeanCode.SendGrid/SendGridRazorClient.cs
+++ b/src/Infrastructure/LeanCode.SendGrid/SendGridRazorClient.cs
@@ -67,7 +67,12 @@ public class SendGridRazorClient
     {
         if (msg is SendGridLocalizedRazorMessage lrmsg)
         {
-            lrmsg.Subject = LocalizeSubject(lrmsg.Culture, lrmsg.Subject, lrmsg.SubjectFormatArgs);
+            lrmsg.Subject ??= LocalizeSubject(
+                lrmsg.Culture,
+                lrmsg.LocalizedSubjectKey
+                    ?? throw new InvalidOperationException("Subject and LocalizedSubjectKey are null."),
+                lrmsg.SubjectFormatArgs
+            );
         }
 
         if (msg.PlainTextContentModel is object plainTextModel)

--- a/src/Infrastructure/LeanCode.SendGrid/SendGridRazorMessageExtensions.cs
+++ b/src/Infrastructure/LeanCode.SendGrid/SendGridRazorMessageExtensions.cs
@@ -136,7 +136,7 @@ public static class SendGridRazorMessageExtensions
     {
         if (message is SendGridLocalizedRazorMessage localized)
         {
-            localized.SetGlobalSubject(subject, null);
+            localized.SetLocalizedSubject(subject, null);
         }
         else
         {
@@ -154,13 +154,20 @@ public static class SendGridRazorMessageExtensions
     {
         if (message is SendGridLocalizedRazorMessage localized)
         {
-            localized.SetGlobalSubject(subject, formatArgs);
+            localized.SetLocalizedSubject(subject, formatArgs);
         }
         else
         {
             var formatted = string.Format(System.Globalization.CultureInfo.InvariantCulture, subject, formatArgs);
             message.SetGlobalSubject(formatted);
         }
+
+        return message;
+    }
+
+    public static SendGridRazorMessage WithLiteralSubject(this SendGridRazorMessage message, string subject)
+    {
+        message.SetGlobalSubject(subject);
 
         return message;
     }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -27,6 +27,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.Testing.Platform" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.analyzers" />

--- a/test/Infrastructure/LeanCode.SendGrid.Tests/SendGridRazorClientTests.cs
+++ b/test/Infrastructure/LeanCode.SendGrid.Tests/SendGridRazorClientTests.cs
@@ -59,7 +59,7 @@ public class SendGridRazorClientTests
     }
 
     [SendGridFact]
-    public async Task Sends_email_correctly()
+    public async Task Sends_localized_email_correctly()
     {
         var msg = new SendGridLocalizedRazorMessage("pl")
             .WithSender(EmailFrom, "LeanCode Tester")
@@ -67,11 +67,20 @@ public class SendGridRazorClientTests
             .WithSubject("email.subject.test")
             .WithPlainTextContent(new EmailTextVM())
             .WithHtmlContent(new EmailHtmlVM())
-            .WithAttachment(
-                Convert.ToBase64String(Encoding.UTF8.GetBytes("Attachment content.")),
-                "Attachment.txt",
-                "text/plain"
-            )
+            .WithAttachment(Convert.ToBase64String("Attachment content."u8.ToArray()), "Attachment.txt", "text/plain")
+            .WithNoTracking();
+
+        await client.SendEmailAsync(msg);
+    }
+
+    [SendGridFact]
+    public async Task Sends_email_with_literal_subject_correctly()
+    {
+        var msg = new SendGridLocalizedRazorMessage("pl")
+            .WithSender(EmailFrom, "LeanCode Tester")
+            .WithRecipient(EmailTo)
+            .WithLiteralSubject("Test email with literal subject")
+            .WithPlainTextContent(new EmailTextVM())
             .WithNoTracking();
 
         await client.SendEmailAsync(msg);
@@ -86,11 +95,7 @@ public class SendGridRazorClientTests
             .WithSubject("email.subject.test")
             .WithPlainTextContent(new EmailTextVM())
             .WithHtmlContent(new EmailHtmlVM())
-            .WithAttachment(
-                Convert.ToBase64String(Encoding.UTF8.GetBytes("Attachment content.")),
-                "Attachment.txt",
-                "text/plain"
-            )
+            .WithAttachment(Convert.ToBase64String("Attachment content."u8.ToArray()), "Attachment.txt", "text/plain")
             .WithNoTracking();
 
         var exception = await Assert.ThrowsAsync<SendGridException>(() => client.SendEmailAsync(msg));

--- a/test/Infrastructure/LeanCode.SendGrid.Tests/SendGridRazorClientTests.cs
+++ b/test/Infrastructure/LeanCode.SendGrid.Tests/SendGridRazorClientTests.cs
@@ -67,7 +67,7 @@ public class SendGridRazorClientTests
             .WithSubject("email.subject.test")
             .WithPlainTextContent(new EmailTextVM())
             .WithHtmlContent(new EmailHtmlVM())
-            .WithAttachment(Convert.ToBase64String("Attachment content."u8.ToArray()), "Attachment.txt", "text/plain")
+            .WithAttachment(Convert.ToBase64String("Attachment content."u8), "Attachment.txt", "text/plain")
             .WithNoTracking();
 
         await client.SendEmailAsync(msg);
@@ -95,7 +95,7 @@ public class SendGridRazorClientTests
             .WithSubject("email.subject.test")
             .WithPlainTextContent(new EmailTextVM())
             .WithHtmlContent(new EmailHtmlVM())
-            .WithAttachment(Convert.ToBase64String("Attachment content."u8.ToArray()), "Attachment.txt", "text/plain")
+            .WithAttachment(Convert.ToBase64String("Attachment content."u8), "Attachment.txt", "text/plain")
             .WithNoTracking();
 
         var exception = await Assert.ThrowsAsync<SendGridException>(() => client.SendEmailAsync(msg));


### PR DESCRIPTION
Also second strike on when I'm implementing something in corelib again and I need to see the tests in my IDE, hence the first commit.