### PR TITLE
Attempt to fix flakiness of `CompiledViewsCacheTests.Stress_test_the_multithreading_part()`

### DIFF
--- a/src/Infrastructure/LeanCode.ViewRenderer.Razor/CompiledViewsCache.cs
+++ b/src/Infrastructure/LeanCode.ViewRenderer.Razor/CompiledViewsCache.cs
@@ -50,6 +50,8 @@ internal class CompiledViewsCache
                     "View type for {ViewName} was added to cache while we were setting up compilation",
                     viewName
                 );
+                // Complete the TCS before removing - other threads may be waiting on it
+                tcs.SetResult(compiled);
                 buildCache.TryRemove(viewName, out _);
                 return new ValueTask<CompiledView>(compiled);
             }

--- a/src/Infrastructure/LeanCode.ViewRenderer.Razor/CompiledViewsCache.cs
+++ b/src/Infrastructure/LeanCode.ViewRenderer.Razor/CompiledViewsCache.cs
@@ -39,6 +39,21 @@ internal class CompiledViewsCache
 
         if (tcs == newTcs)
         {
+            // Double-check the main cache. This handles the race condition where:
+            // 1. We checked cache above → miss
+            // 2. Another thread finished compilation, added to cache, and removed from buildCache
+            // 3. We added our TCS to buildCache (which was now empty)
+            // Without this check, we'd start a redundant compilation.
+            if (cache.TryGetValue(viewName, out compiled))
+            {
+                logger.Verbose(
+                    "View type for {ViewName} was added to cache while we were setting up compilation",
+                    viewName
+                );
+                buildCache.TryRemove(viewName, out _);
+                return new ValueTask<CompiledView>(compiled);
+            }
+
             return new ValueTask<CompiledView>(WrappedCompileAsync(viewName, tcs));
         }
 


### PR DESCRIPTION
https://github.com/leancodepl/corelibrary/actions/runs/19758582260/job/56615140218?pr=792

I'm not sure if that's the right approach and there already is a task for refactoring this whole thing, but that might help for now?