### PR TITLE
Revert CQRS middleware response serialization responsibility approach

### DIFF
--- a/docs/cqrs/pipeline/adding_custom_middlewares.md
+++ b/docs/cqrs/pipeline/adding_custom_middlewares.md
@@ -50,10 +50,10 @@ Moreover, CoreLibrary provides extension methods for `HttpContext`, which can be
 
 * `GetCQRSRequiredResultPayload<TPayload>()`: Returns the strongly-typed result payload, throwing an exception if the execution result or payload is not present.
 
-* `CompleteCQRSExecutionResult(ExecutionResult result)`: This method should be called when a custom middleware short-circuits the pipeline and needs to return a result payload. It properly sets the [ExecutionResult] and serializes it to the response body. If your middleware returns a response without calling the next middleware, use this method to ensure the response is correctly formatted.
+* `SetCQRSExecutionResult(ExecutionResult result)`: This method sets the [ExecutionResult] in the HttpContext features. Use this when your middleware needs to short-circuit the pipeline and return a result. The response will be automatically serialized at the pipeline boundary (by [CQRSMiddleware]).
 
-!!! warning "Short-Circuiting Middlewares"
-    If your custom middleware short-circuits the pipeline (i.e., doesn't call `await next(context)`) and needs to return a CQRS result payload, you **must** call `await context.CompleteCQRSExecutionResult(result)` ([CompleteCQRSExecutionResult]) to properly serialize the response. Simply setting the response manually will not work correctly with the CQRS pipeline in local execution.
+!!! tip "Short-Circuiting Middlewares"
+    If your custom middleware short-circuits the pipeline (i.e., doesn't call `await next(context)`), you have two options: **set the `ExecutionResult`** by calling `context.SetCQRSExecutionResult(result)` and then `return` (serialization is handled automatically by [CQRSMiddleware]), or **write the response directly** to `context.Response` if you need more control (e.g., streaming). In the latter case, you do not have to set the `ExecutionResult` - the [CQRSMiddleware] will skip serialization if the response has already started.
 
 Here's an example of a middleware that short-circuits and returns a cached result:
 
@@ -62,7 +62,7 @@ public class CustomCachedResultMiddleware : IMiddleware
 {
     private readonly IResultCache cache;
 
-    public CachedResultMiddleware(IResultCache cache)
+    public CustomCachedResultMiddleware(IResultCache cache)
     {
         this.cache = cache;
     }
@@ -74,10 +74,9 @@ public class CustomCachedResultMiddleware : IMiddleware
 
         if (cache.TryGet(cacheKey, out var cachedResult))
         {
-            // Short-circuit: return cached result without calling next()
-            await context.CompleteCQRSExecutionResult(
-                new ExecutionResult(200, cachedResult, hasPayload: true)
-            );
+            // Short-circuit: set result and return without calling next()
+            // Serialization is handled automatically by CQRSMiddleware
+            context.SetCQRSExecutionResult(ExecutionResult.WithPayload(cachedResult));
             return;
         }
 
@@ -85,10 +84,10 @@ public class CustomCachedResultMiddleware : IMiddleware
         await next(context);
 
         // Cache the result after execution
-        var result = context.GetCQRSRequestPayload().Result;
+        var result = context.GetCQRSExecutionResult();
         if (result?.StatusCode == 200)
         {
-            cache.Set(cacheKey, result.Payload);
+            cache.Set(cacheKey, result.Value.Payload);
         }
     }
 }
@@ -132,4 +131,4 @@ After configuration above, you can integrate `EmployeeBlockerMiddleware` into th
 [CQRSObjectMetadata]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.Execution/CQRSObjectMetadata.cs
 [CQRSRequestPayload]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.Execution/CQRSRequestPayload.cs
 [ExecutionResult]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.Execution/ExecutionResult.cs
-[CompleteCQRSExecutionResult]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.AspNetCore/HttpContextExtensions.cs#L13
+[CQRSMiddleware]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs

--- a/docs/cqrs/pipeline/index.md
+++ b/docs/cqrs/pipeline/index.md
@@ -120,15 +120,14 @@ sequenceDiagram
     middle ->> final: next()
 
     Note over final: Execute handler
-    Note over final: Set result in CQRSRequestPayload
+    Note over final: Set ExecutionResult
 
     final ->> middle: #0160;
     Note over middle: Custom middlewares, e.g. events publication
 
     middle ->> start: #0160;
 
-    Note over start: Set response headers
-    Note over start: Serialize result
+    Note over start: Serialize ExecutionResult to response
 
     start ->> aspnet: #0160;
 
@@ -136,9 +135,12 @@ sequenceDiagram
 
 The process begins with the invocation of common ASP.NET middlewares, such as `UseAuthentication` and `UseCors`, prior to the execution of the [MapRemoteCQRS(...)] method. This method, adds the [CQRSMiddleware], initiating the pipeline. During this stage, the request undergoes deserialization and the [CQRSRequestPayload] is set on `HttpContext`.
 
-Subsequently, the pipeline executes additional custom middlewares, responsible for tasks like [authorization], [validation] or [output-caching]. Following the successful execution of these middlewares, the specific handler is invoked inside [CQRSPipelineFinalizer]. Upon handler execution, the result is assigned to the [CQRSRequestPayload].
+Subsequently, the pipeline executes additional custom middlewares, responsible for tasks like [authorization], [validation] or [output-caching]. Following the successful execution of these middlewares, the specific handler is invoked inside [CQRSPipelineFinalizer]. Upon handler execution, the [ExecutionResult] is set on the `HttpContext`.
 
-[EventsPublisherMiddleware] then facilitates the publication of events (assuming it's added to the pipeline in [MapRemoteCQRS(...)]). Towards the conclusion of the pipeline, response headers are configured, and the result is serialized inside [CQRSMiddleware]. Finally, the serialized result is returned to the client, completing the request handling process.
+[EventsPublisherMiddleware] then facilitates the publication of events (assuming it's added to the pipeline in [MapRemoteCQRS(...)]). Towards the conclusion of the pipeline, the [ExecutionResult] is serialized to the response inside [CQRSMiddleware]. Finally, the serialized result is returned to the client, completing the request handling process.
+
+!!! note "Serialization with Output Caching"
+    When output caching is enabled via `.CacheOutput()`, the serialization is handled differently. A [CQRSResponseSerializerMiddleware] is added after the OutputCache middleware to ensure proper serialization timing for cache storage. In this case, [CQRSMiddleware] delegates serialization to that middleware.
 
 [AddCQRS(...)]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs#L17
 [CQRSServicesBuilder]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.AspNetCore/ServiceCollectionCQRSExtensions.cs#L46
@@ -162,6 +164,8 @@ Subsequently, the pipeline executes additional custom middlewares, responsible f
 [CQRSMiddleware]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
 [CQRSRequestPayload]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.Execution/CQRSRequestPayload.cs
 [CQRSPipelineFinalizer]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSPipelineFinalizer.cs
+[ExecutionResult]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.Execution/ExecutionResult.cs
+[CQRSResponseSerializerMiddleware]: https://github.com/leancodepl/corelibrary/blob/HEAD/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSResponseSerializerMiddleware.cs
 [Commands]: ../command/index.md
 [Queries]: ../query/index.md
 [Operations]: ../operation/index.md

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSApplicationBuilder.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/CQRSApplicationBuilder.cs
@@ -49,7 +49,10 @@ public static class CQRSApplicationBuilderExtensions
 
     public static ICQRSApplicationBuilder CacheOutput(this ICQRSApplicationBuilder builder)
     {
-        builder.UseMiddleware<CQRSOutputCachingObservabilityMiddleware>().UseOutputCache();
+        builder
+            .UseMiddleware<CQRSOutputCachingObservabilityMiddleware>()
+            .UseOutputCache()
+            .UseMiddleware<CQRSResponseSerializerMiddleware>();
         return builder;
     }
 

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/HttpContextExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/HttpContextExtensions.cs
@@ -10,6 +10,13 @@ public static class HttpContextExtensions
 {
     private static readonly ReadOnlyMemory<byte> NullString = "null"u8.ToArray();
 
+    public static bool IsHttpResponseSet(this HttpContext httpContext)
+    {
+        var response = httpContext.Response;
+
+        return response.HasStarted || response.StatusCode != StatusCodes.Status200OK || response.ContentLength.HasValue;
+    }
+
     public static async Task SerializeCQRSResultAsync(this HttpContext httpContext)
     {
         if (httpContext.Response is NullHttpResponse)

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/HttpContextExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/HttpContextExtensions.cs
@@ -10,26 +10,17 @@ public static class HttpContextExtensions
 {
     private static readonly ReadOnlyMemory<byte> NullString = "null"u8.ToArray();
 
-    public static async Task CompleteCQRSExecutionResult(this HttpContext httpContext, ExecutionResult result)
+    public static async Task SerializeCQRSResultAsync(this HttpContext httpContext)
     {
-        httpContext.Features.Set(result);
-
         if (httpContext.Response is NullHttpResponse)
         {
-            return;
+            throw new InvalidOperationException("Cannot serialize CQRS result to NullHttpResponse.");
         }
 
         var serializer = httpContext.RequestServices.GetRequiredService<ISerializer>();
-        await SerializeCQRSResultAsync(httpContext, result, serializer);
-    }
 
-    private static async Task SerializeCQRSResultAsync(
-        HttpContext httpContext,
-        ExecutionResult result,
-        ISerializer serializer
-    )
-    {
         var objectMetadata = httpContext.GetCQRSObjectMetadata();
+        var result = httpContext.GetCQRSRequiredExecutionResult();
 
         httpContext.Response.StatusCode = result.StatusCode;
         if (!result.HasPayload)

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Local/Context/NullHttpResponse.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Local/Context/NullHttpResponse.cs
@@ -13,25 +13,25 @@ internal class NullHttpResponse : HttpResponse
     public override long? ContentLength
     {
         get => null;
-        set { }
+        set => throw new InvalidOperationException("Cannot set ContentLength on NullHttpResponse.");
     }
 
     public override int StatusCode
     {
         get => 0;
-        set { }
+        set => throw new InvalidOperationException("Cannot set StatusCode on NullHttpResponse.");
     }
 
     public override string? ContentType
     {
         get => null;
-        set { }
+        set => throw new InvalidOperationException("Cannot set ContentType on NullHttpResponse.");
     }
 
     public override Stream Body
     {
         get => Stream.Null;
-        set { }
+        set => throw new InvalidOperationException("Cannot set Body on NullHttpResponse.");
     }
 
     public NullHttpResponse(HttpContext context)

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Local/Context/NullHttpResponse.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Local/Context/NullHttpResponse.cs
@@ -13,25 +13,25 @@ internal class NullHttpResponse : HttpResponse
     public override long? ContentLength
     {
         get => null;
-        set => throw new InvalidOperationException("Cannot set ContentLength on NullHttpResponse.");
+        set { }
     }
 
     public override int StatusCode
     {
         get => 0;
-        set => throw new InvalidOperationException("Cannot set StatusCode on NullHttpResponse.");
+        set { }
     }
 
     public override string? ContentType
     {
         get => null;
-        set => throw new InvalidOperationException("Cannot set ContentType on NullHttpResponse.");
+        set { }
     }
 
     public override Stream Body
     {
         get => Stream.Null;
-        set => throw new InvalidOperationException("Cannot set Body on NullHttpResponse.");
+        set { }
     }
 
     public NullHttpResponse(HttpContext context)

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSExceptionTranslationMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSExceptionTranslationMiddleware.cs
@@ -49,7 +49,7 @@ public class CQRSExceptionTranslationMiddleware
             logger.Warning("Command {@Command} is not valid with result {@Result}", cqrsPayload.Payload, result);
 
             var executionResult = ExecutionResult.WithPayload(result, StatusCodes.Status422UnprocessableEntity);
-            await httpContext.CompleteCQRSExecutionResult(executionResult);
+            httpContext.SetCQRSExecutionResult(executionResult);
         }
     }
 

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
@@ -69,6 +69,11 @@ public class CQRSMiddleware
         try
         {
             await next(httpContext);
+
+            if (!httpContext.Response.HasStarted)
+            {
+                await httpContext.SerializeCQRSResultAsync();
+            }
         }
         catch (Exception ex) when (ex is OperationCanceledException || ex.InnerException is OperationCanceledException)
         {

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
@@ -70,7 +70,7 @@ public class CQRSMiddleware
         {
             await next(httpContext);
 
-            if (!httpContext.Response.HasStarted)
+            if (httpContext.Response is { HasStarted: false, StatusCode: StatusCodes.Status200OK })
             {
                 await httpContext.SerializeCQRSResultAsync();
             }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSMiddleware.cs
@@ -70,7 +70,7 @@ public class CQRSMiddleware
         {
             await next(httpContext);
 
-            if (httpContext.Response is { HasStarted: false, StatusCode: StatusCodes.Status200OK })
+            if (!httpContext.IsHttpResponseSet())
             {
                 await httpContext.SerializeCQRSResultAsync();
             }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSPipelineFinalizer.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSPipelineFinalizer.cs
@@ -14,6 +14,6 @@ internal static class CQRSPipelineFinalizer
 
         var result = await metadata.ObjectExecutor(context, payload);
 
-        await context.CompleteCQRSExecutionResult(ExecutionResult.WithPayload(result));
+        context.SetCQRSExecutionResult(ExecutionResult.WithPayload(result));
     }
 }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSResponseSerializerMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSResponseSerializerMiddleware.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Http;
+
+namespace LeanCode.CQRS.AspNetCore.Middleware;
+
+public class CQRSResponseSerializerMiddleware
+{
+    private readonly RequestDelegate next;
+
+    public CQRSResponseSerializerMiddleware(RequestDelegate next)
+    {
+        this.next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext httpContext)
+    {
+        await next(httpContext);
+        if (!httpContext.Response.HasStarted)
+        {
+            await httpContext.SerializeCQRSResultAsync();
+        }
+    }
+}

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSResponseSerializerMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSResponseSerializerMiddleware.cs
@@ -14,7 +14,7 @@ public class CQRSResponseSerializerMiddleware
     public async Task InvokeAsync(HttpContext httpContext)
     {
         await next(httpContext);
-        if (!httpContext.Response.HasStarted)
+        if (!httpContext.IsHttpResponseSet())
         {
             await httpContext.SerializeCQRSResultAsync();
         }

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSSecurityMiddleware.cs
@@ -46,7 +46,7 @@ public class CQRSSecurityMiddleware
                 payload.Payload
             );
 
-            await context.CompleteCQRSExecutionResult(ExecutionResult.Empty(StatusCodes.Status401Unauthorized));
+            context.SetCQRSExecutionResult(ExecutionResult.Empty(StatusCodes.Status401Unauthorized));
             return;
         }
         activity?.SetTag("security.user_authenticated", true);
@@ -77,7 +77,7 @@ public class CQRSSecurityMiddleware
                     customAuthorizer.GetType().FullName
                 );
 
-                await context.CompleteCQRSExecutionResult(ExecutionResult.Empty(StatusCodes.Status403Forbidden));
+                context.SetCQRSExecutionResult(ExecutionResult.Empty(StatusCodes.Status403Forbidden));
                 return;
             }
             else

--- a/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSValidationMiddleware.cs
+++ b/src/CQRS/LeanCode.CQRS.AspNetCore/Middleware/CQRSValidationMiddleware.cs
@@ -52,7 +52,7 @@ public class CQRSValidationMiddleware
             logger.Warning("Command {@Command} is not valid with result {@Result}", payload.Payload, result);
 
             var commandResult = CommandResult.NotValid(result);
-            await httpContext.CompleteCQRSExecutionResult(
+            httpContext.SetCQRSExecutionResult(
                 ExecutionResult.WithPayload(commandResult, StatusCodes.Status422UnprocessableEntity)
             );
             return;

--- a/src/CQRS/LeanCode.CQRS.Execution/ExecutionResult.cs
+++ b/src/CQRS/LeanCode.CQRS.Execution/ExecutionResult.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http;
+
 namespace LeanCode.CQRS.Execution;
 
 public readonly record struct ExecutionResult
@@ -12,7 +14,7 @@ public readonly record struct ExecutionResult
 
     public static ExecutionResult Empty(int code) => new() { StatusCode = code };
 
-    public static ExecutionResult WithPayload(object? payload, int code = 200) =>
+    public static ExecutionResult WithPayload(object? payload, int code = StatusCodes.Status200OK) =>
         new()
         {
             StatusCode = code,

--- a/src/CQRS/LeanCode.CQRS.Execution/HttpContextExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.Execution/HttpContextExtensions.cs
@@ -31,7 +31,7 @@ public static class HttpContextExtensions
 
     public static ExecutionResult? GetCQRSExecutionResult(this HttpContext httpContext)
     {
-        return httpContext.Features.Get<ExecutionResult>();
+        return httpContext.Features.Get<ExecutionResult?>();
     }
 
     public static TPayload? GetCQRSResultPayload<TPayload>(this HttpContext httpContext)
@@ -47,6 +47,16 @@ public static class HttpContextExtensions
     public static TPayload GetCQRSRequiredResultPayload<TPayload>(this HttpContext httpContext)
     {
         return (TPayload)httpContext.GetCQRSRequiredExecutionResult().Payload!;
+    }
+
+    public static void SetCQRSExecutionResult(this HttpContext httpContext, ExecutionResult result)
+    {
+        if (httpContext.GetCQRSExecutionResult() is not null)
+        {
+            throw new InvalidOperationException("The CQRS execution result has been already set.");
+        }
+
+        httpContext.Features.Set(result);
     }
 
     public static void SetCQRSObjectMetadataForLocalExecution(this HttpContext httpContext, CQRSObjectMetadata metadata)

--- a/src/CQRS/LeanCode.CQRS.Execution/HttpContextExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.Execution/HttpContextExtensions.cs
@@ -42,7 +42,7 @@ public static class HttpContextExtensions
     public static ExecutionResult GetCQRSRequiredExecutionResult(this HttpContext httpContext)
     {
         return httpContext.GetCQRSExecutionResult()
-            ?? throw new InvalidOperationException("Execution result is not set is HttpContext features.");
+            ?? throw new InvalidOperationException("Execution result is not set in HttpContext features.");
     }
 
     public static TPayload GetCQRSRequiredResultPayload<TPayload>(this HttpContext httpContext)

--- a/src/CQRS/LeanCode.CQRS.Execution/HttpContextExtensions.cs
+++ b/src/CQRS/LeanCode.CQRS.Execution/HttpContextExtensions.cs
@@ -41,7 +41,8 @@ public static class HttpContextExtensions
 
     public static ExecutionResult GetCQRSRequiredExecutionResult(this HttpContext httpContext)
     {
-        return httpContext.Features.GetRequiredFeature<ExecutionResult>();
+        return httpContext.GetCQRSExecutionResult()
+            ?? throw new InvalidOperationException("Execution result is not set is HttpContext features.");
     }
 
     public static TPayload GetCQRSRequiredResultPayload<TPayload>(this HttpContext httpContext)
@@ -56,7 +57,7 @@ public static class HttpContextExtensions
             throw new InvalidOperationException("The CQRS execution result has been already set.");
         }
 
-        httpContext.Features.Set(result);
+        httpContext.Features.Set<ExecutionResult?>(result);
     }
 
     public static void SetCQRSObjectMetadataForLocalExecution(this HttpContext httpContext, CQRSObjectMetadata metadata)

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/OutputCache/RemoteCQRSOutputCachingTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests.Integration/OutputCache/RemoteCQRSOutputCachingTests.cs
@@ -99,7 +99,7 @@ public class RemoteCQRSOutputCachingTests : RemoteCQRSTestsBase
         var (secondBody, secondStatusCode, _) = await SendAsync(
             CachedQueryPath,
             DefaultBody,
-            headers: new() { { HeaderNames.IfNoneMatch, etag } }
+            headers: new() { [HeaderNames.IfNoneMatch] = etag }
         );
         secondStatusCode.Should().Be(HttpStatusCode.NotModified);
         secondBody.Should().BeEmpty();
@@ -116,7 +116,7 @@ public class RemoteCQRSOutputCachingTests : RemoteCQRSTestsBase
         var (secondBody, secondStatusCode, secondHeaders) = await SendAsync(
             CachedQueryPath,
             DefaultBody,
-            headers: new() { { HeaderNames.IfNoneMatch, "\"different-etag\"" } }
+            headers: new() { [HeaderNames.IfNoneMatch] = "\"different-etag\"" }
         );
         secondStatusCode.Should().Be(HttpStatusCode.OK);
         secondBody.Should().NotBeEmpty();

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Local/MiddlewareBasedLocalExecutorTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Local/MiddlewareBasedLocalExecutorTests.cs
@@ -180,7 +180,7 @@ public class LocalHandlerMiddleware : IMiddleware
         if (context.Request.Headers.TryGetValue(StatusHeader, out var value))
         {
             var code = int.Parse(value!, CultureInfo.InvariantCulture);
-            await context.CompleteCQRSExecutionResult(ExecutionResult.Empty(code));
+            context.SetCQRSExecutionResult(ExecutionResult.Empty(code));
         }
         else
         {

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSExceptionTranslationMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSExceptionTranslationMiddlewareTests.cs
@@ -50,7 +50,11 @@ public sealed class CQRSExceptionTranslationMiddlewareTests : CQRSMiddlewareTest
     [Fact]
     public async Task Regular_flow_is_not_interrupted()
     {
-        FinalPipeline = ctx => ctx.CompleteCQRSExecutionResult(ExecutionResult.WithPayload(CommandResult.Success));
+        FinalPipeline = ctx =>
+        {
+            ctx.SetCQRSExecutionResult(ExecutionResult.WithPayload(CommandResult.Success));
+            return Task.CompletedTask;
+        };
 
         var httpContext = await SendAsync();
 

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSExceptionTranslationMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSExceptionTranslationMiddlewareTests.cs
@@ -25,13 +25,9 @@ public sealed class CQRSExceptionTranslationMiddlewareTests : CQRSMiddlewareTest
         var httpContext = await SendAsync();
 
         var commandResult = httpContext
-            .ShouldHaveResponseStatusCode(StatusCodes.Status422UnprocessableEntity)
-            .ShouldHaveResponseContentType(Serializer.ContentType)
             .ShouldContainExecutionResult(StatusCodes.Status422UnprocessableEntity)
             .ShouldContainCommandResult();
         commandResult.ShouldFailWithValidationErrors(new ValidationError("", "error message", 23));
-
-        Serializer.ShouldHaveSerialized(commandResult);
 
         VerifyCQRSFailureMetrics(CQRSMetrics.ValidationFailure, 1);
     }
@@ -59,13 +55,9 @@ public sealed class CQRSExceptionTranslationMiddlewareTests : CQRSMiddlewareTest
         var httpContext = await SendAsync();
 
         var commandResult = httpContext
-            .ShouldHaveResponseStatusCode(StatusCodes.Status200OK)
-            .ShouldHaveResponseContentType(Serializer.ContentType)
             .ShouldContainExecutionResult(StatusCodes.Status200OK)
             .ShouldContainCommandResult();
         commandResult.ShouldBeSuccessful();
-
-        Serializer.ShouldHaveSerialized(commandResult);
 
         VerifyCQRSFailureMetrics(CQRSMetrics.ValidationFailure, 0);
     }

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTests.cs
@@ -24,8 +24,6 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
         (_, _) => Task.FromResult<object?>(FinalResult)
     );
 
-    private Func<HttpContext, ExecutionResult?> IntermediatePipeline { get; set; } = _ => null;
-
     protected override void ConfigureServices(IServiceCollection services)
     {
         services.AddLogging(logging => logging.AddNullLeanCodeLogger());
@@ -33,17 +31,7 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
 
     public CQRSMiddlewareTests()
     {
-        FinalPipeline = async ctx =>
-        {
-            if (IntermediatePipeline(ctx) is { } result)
-            {
-                ctx.SetCQRSExecutionResult(result);
-            }
-            else
-            {
-                await CQRSPipelineFinalizer.HandleAsync(ctx);
-            }
-        };
+        FinalPipeline = CQRSPipelineFinalizer.HandleAsync;
     }
 
     [Fact]
@@ -100,7 +88,11 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
         var queryResult = new QueryResult();
 
         Serializer.SetDeserializeResult(query);
-        IntermediatePipeline = _ => ExecutionResult.WithPayload(queryResult, StatusCodes.Status202Accepted);
+        FinalPipeline = ctx =>
+        {
+            ctx.SetCQRSExecutionResult(ExecutionResult.WithPayload(queryResult, StatusCodes.Status202Accepted));
+            return Task.CompletedTask;
+        };
 
         var httpContext = await SendAsync();
 
@@ -121,7 +113,11 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
         var query = new Query();
 
         Serializer.SetDeserializeResult(query);
-        IntermediatePipeline = _ => ExecutionResult.Empty(StatusCodes.Status418ImATeapot);
+        FinalPipeline = ctx =>
+        {
+            ctx.SetCQRSExecutionResult(ExecutionResult.Empty(StatusCodes.Status418ImATeapot));
+            return Task.CompletedTask;
+        };
 
         var httpContext = await SendAsync();
 
@@ -146,7 +142,11 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
         var queryResult = new QueryRuntimeResult();
 
         Serializer.SetDeserializeResult(query);
-        IntermediatePipeline = _ => ExecutionResult.WithPayload(queryResult, StatusCodes.Status200OK);
+        FinalPipeline = ctx =>
+        {
+            ctx.SetCQRSExecutionResult(ExecutionResult.WithPayload(queryResult, StatusCodes.Status200OK));
+            return Task.CompletedTask;
+        };
 
         var httpContext = await SendAsync();
 
@@ -161,13 +161,23 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
         VerifyCQRSSuccessMetrics(1);
     }
 
-    [Fact]
-    public async Task Returns_500InternalServerError_if_pipeline_execution_thrown_an_exception()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Returns_500InternalServerError_if_pipeline_execution_thrown_an_exception(
+        bool thrownAfterFinalizer
+    )
     {
         var query = new Query();
         Serializer.SetDeserializeResult(query);
-
-        IntermediatePipeline = _ => throw new InvalidOperationException();
+        FinalPipeline = async ctx =>
+        {
+            if (thrownAfterFinalizer)
+            {
+                await CQRSPipelineFinalizer.HandleAsync(ctx);
+            }
+            throw new InvalidOperationException();
+        };
 
         var httpContext = await SendAsync();
 
@@ -188,11 +198,11 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
 
         object interceptedPayload = null!;
 
-        IntermediatePipeline = ctx =>
+        FinalPipeline = ctx =>
         {
             var payload = ctx.GetCQRSRequestPayload();
             interceptedPayload = payload.Payload;
-            return null;
+            return Task.CompletedTask;
         };
 
         await SendAsync();

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSMiddlewareTests.cs
@@ -33,10 +33,17 @@ public sealed class CQRSMiddlewareTests : CQRSMiddlewareTestBase<CQRSMiddleware>
 
     public CQRSMiddlewareTests()
     {
-        FinalPipeline = ctx =>
-            IntermediatePipeline(ctx) is { } result
-                ? ctx.CompleteCQRSExecutionResult(result)
-                : CQRSPipelineFinalizer.HandleAsync(ctx);
+        FinalPipeline = async ctx =>
+        {
+            if (IntermediatePipeline(ctx) is { } result)
+            {
+                ctx.SetCQRSExecutionResult(result);
+            }
+            else
+            {
+                await CQRSPipelineFinalizer.HandleAsync(ctx);
+            }
+        };
     }
 
     [Fact]

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSOutputCachingObservabilityMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSOutputCachingObservabilityMiddlewareTests.cs
@@ -32,12 +32,20 @@ public class CQRSOutputCachingObservabilityMiddlewareTests : CQRSMiddlewareTestB
     private readonly MetricCollector<int> cqrsCacheMissMetricCollector;
 
     public CQRSOutputCachingObservabilityMiddlewareTests()
-        : base(app => app.UseMiddleware<CQRSOutputCachingObservabilityMiddleware>().UseOutputCache())
+        : base(app =>
+            app.UseMiddleware<CQRSOutputCachingObservabilityMiddleware>()
+                .UseOutputCache()
+                .UseMiddleware<CQRSResponseSerializerMiddleware>()
+        )
     {
         cqrsCacheHitMetricCollector = new(CQRSOutputCacheMetrics.CqrsOutputCacheHit);
         cqrsCacheMissMetricCollector = new(CQRSOutputCacheMetrics.CqrsOutputCacheMiss);
 
-        FinalPipeline = ctx => ctx.CompleteCQRSExecutionResult(ExecutionResult.WithPayload(new TestQueryResult(42)));
+        FinalPipeline = ctx =>
+        {
+            ctx.SetCQRSExecutionResult(ExecutionResult.WithPayload(new TestQueryResult(42)));
+            return Task.CompletedTask;
+        };
     }
 
     protected override void ConfigureServices(IServiceCollection services)

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
@@ -30,7 +30,11 @@ public sealed class CQRSSecurityMiddlewareTests : CQRSMiddlewareTestBase<CQRSSec
 
     public CQRSSecurityMiddlewareTests()
     {
-        FinalPipeline = ctx => ctx.CompleteCQRSExecutionResult(ExecutionResult.WithPayload(null));
+        FinalPipeline = ctx =>
+        {
+            ctx.SetCQRSExecutionResult(ExecutionResult.WithPayload(null));
+            return Task.CompletedTask;
+        };
     }
 
     protected override void ConfigureServices(IServiceCollection services)

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSSecurityMiddlewareTests.cs
@@ -140,10 +140,7 @@ public sealed class CQRSSecurityMiddlewareTests : CQRSMiddlewareTestBase<CQRSSec
 
     private void AssertAuthorizationSuccess(HttpContext context)
     {
-        context
-            .ShouldHaveResponseStatusCode(StatusCodes.Status200OK)
-            .ShouldHaveResponseContentType(Serializer.ContentType)
-            .ShouldContainExecutionResult(StatusCodes.Status200OK);
+        context.ShouldContainExecutionResult(StatusCodes.Status200OK);
 
         VerifyNoCQRSSuccessMetrics();
         VerifyNoCQRSFailureMetrics();
@@ -152,7 +149,7 @@ public sealed class CQRSSecurityMiddlewareTests : CQRSMiddlewareTestBase<CQRSSec
 
     private void AssertAuthorizationFailure(HttpContext context, int errorCode = StatusCodes.Status403Forbidden)
     {
-        context.ShouldHaveResponseStatusCode(errorCode).ShouldContainExecutionResult(errorCode);
+        context.ShouldContainExecutionResult(errorCode);
 
         VerifyCQRSFailureMetrics(CQRSMetrics.AuthorizationFailure, 1);
         VerifyActivity("middleware - Security");

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSValidationMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSValidationMiddlewareTests.cs
@@ -45,13 +45,7 @@ public sealed class CQRSValidationMiddlewareTests : CQRSMiddlewareTestBase<CQRSV
     {
         var ctx = await SendAsync(new UnvalidatedCommand());
 
-        var commandResult = ctx.ShouldHaveResponseStatusCode(StatusCodes.Status200OK)
-            .ShouldHaveResponseContentType(Serializer.ContentType)
-            .ShouldContainExecutionResult(StatusCodes.Status200OK)
-            .ShouldContainCommandResult();
-        commandResult.ShouldBeSuccessful();
-
-        Serializer.ShouldHaveSerialized(commandResult);
+        ctx.ShouldContainExecutionResult(StatusCodes.Status200OK).ShouldContainCommandResult().ShouldBeSuccessful();
 
         VerifyActivity("middleware - Validation");
     }
@@ -88,13 +82,9 @@ public sealed class CQRSValidationMiddlewareTests : CQRSMiddlewareTestBase<CQRSV
     private void AssertCommandResultSuccess(HttpContext httpContext)
     {
         var commandResult = httpContext
-            .ShouldHaveResponseStatusCode(StatusCodes.Status200OK)
-            .ShouldHaveResponseContentType(Serializer.ContentType)
             .ShouldContainExecutionResult(StatusCodes.Status200OK)
             .ShouldContainCommandResult();
         commandResult.ShouldBeSuccessful();
-
-        Serializer.ShouldHaveSerialized(commandResult);
 
         VerifyActivity("middleware - Validation", activityStatusCode: ActivityStatusCode.Ok);
         VerifyNoCQRSSuccessMetrics();
@@ -103,14 +93,10 @@ public sealed class CQRSValidationMiddlewareTests : CQRSMiddlewareTestBase<CQRSV
 
     private void AssertCommandResultFailure(HttpContext httpContext, params ValidationError[] errors)
     {
-        var commandResult = httpContext
-            .ShouldHaveResponseStatusCode(StatusCodes.Status422UnprocessableEntity)
-            .ShouldHaveResponseContentType(Serializer.ContentType)
+        httpContext
             .ShouldContainExecutionResult(StatusCodes.Status422UnprocessableEntity)
-            .ShouldContainCommandResult();
-        commandResult.ShouldFailWithValidationErrors(errors);
-
-        Serializer.ShouldHaveSerialized(commandResult);
+            .ShouldContainCommandResult()
+            .ShouldFailWithValidationErrors(errors);
 
         VerifyActivity("middleware - Validation");
         VerifyCQRSFailureMetrics(CQRSMetrics.ValidationFailure, 1);

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSValidationMiddlewareTests.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/CQRSValidationMiddlewareTests.cs
@@ -27,7 +27,11 @@ public sealed class CQRSValidationMiddlewareTests : CQRSMiddlewareTestBase<CQRSV
         validatorResolver.FindCommandValidator(typeof(UnvalidatedCommand)).Returns(null as ICommandValidatorWrapper);
         validatorResolver.FindCommandValidator(typeof(ValidatedCommand)).Returns(validator);
 
-        FinalPipeline = ctx => ctx.CompleteCQRSExecutionResult(ExecutionResult.WithPayload(CommandResult.Success));
+        FinalPipeline = ctx =>
+        {
+            ctx.SetCQRSExecutionResult(ExecutionResult.WithPayload(CommandResult.Success));
+            return Task.CompletedTask;
+        };
     }
 
     protected override void ConfigureServices(IServiceCollection services)

--- a/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/TestHelpers.cs
+++ b/test/CQRS/LeanCode.CQRS.AspNetCore.Tests/Middleware/TestHelpers.cs
@@ -23,7 +23,7 @@ public static class TestHelpers
         var result = httpContext.GetCQRSExecutionResult();
 
         result.Should().NotBeNull("because httpContext should contain cqrs execution result");
-        result!.Value.StatusCode.Should().Be(statusCode);
+        result.Value.StatusCode.Should().Be(statusCode);
         if (payload is not null)
         {
             result.Value.Payload.Should().Be(payload);
@@ -50,7 +50,6 @@ public static class TestHelpers
     public static void ShouldFailWithValidationErrors(this CommandResult commandResult, params ValidationError[] errors)
     {
         using var _ = new AssertionScope();
-
         commandResult.WasSuccessful.Should().BeFalse();
         commandResult.ValidationErrors.Should().BeEquivalentTo(errors);
     }


### PR DESCRIPTION
So now we kind of went back with what we're requiring from the CQRS middlewares. They either:
- need to set the `ExecutionResult` on the `HttpContext`
- provide (set?) the whole `HttpResponse` if they know what they're doing, as it might begin to be sent to client right away

So `CQRSMiddleware` will again serialize the  `ExecutionResult`, if non other middleware has "claimed" the HttpResponse (detected with hopefully reasonable heuristics), which is a new twist I guess.

To ensure that `OutputCachingMiddleware` always has the `HttpResponse` prepared to be stored into cache, a `CQRSResponseSerializerMiddleware` is always added after it, which has the same serialization logic as in `CQRSMiddleware`.

Aaaand the detected case, of pipeline returning status code 200 after some exception was thrown after `CQRSPipelineFinalizer` was run, has a dedicated test.