### PR TITLE
Optimize TypedId source generator for proper incremental caching

### DIFF
--- a/src/Domain/LeanCode.DomainModels.Generators/TypedIdData.cs
+++ b/src/Domain/LeanCode.DomainModels.Generators/TypedIdData.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 
 namespace LeanCode.DomainModels.Generators;
 
-public sealed class TypedIdData
+public readonly struct TypedIdData : IEquatable<TypedIdData>
 {
     public TypedIdFormat Format { get; }
     public string Namespace { get; }
@@ -11,6 +11,8 @@ public sealed class TypedIdData
     public bool SkipRandomGenerator { get; }
     public int? MaxValueLength { get; }
     public bool IsValid { get; }
+
+    // Excluded from equality comparison because it's not stable across compilations.
     public Location? Location { get; }
 
     public TypedIdData(
@@ -33,4 +35,25 @@ public sealed class TypedIdData
         IsValid = isValid;
         Location = location;
     }
+
+    public bool Equals(TypedIdData other) =>
+        (Format, Namespace, TypeName, CustomPrefix, SkipRandomGenerator, MaxValueLength, IsValid)
+        == (
+            other.Format,
+            other.Namespace,
+            other.TypeName,
+            other.CustomPrefix,
+            other.SkipRandomGenerator,
+            other.MaxValueLength,
+            other.IsValid
+        );
+
+    public override bool Equals(object? obj) => obj is TypedIdData other && Equals(other);
+
+    public override int GetHashCode() =>
+        (Format, Namespace, TypeName, CustomPrefix, SkipRandomGenerator, MaxValueLength, IsValid).GetHashCode();
+
+    public static bool operator ==(TypedIdData left, TypedIdData right) => left.Equals(right);
+
+    public static bool operator !=(TypedIdData left, TypedIdData right) => !left.Equals(right);
 }

--- a/test/Domain/LeanCode.DomainModels.Tests/Generators/TypedIdDataTests.cs
+++ b/test/Domain/LeanCode.DomainModels.Tests/Generators/TypedIdDataTests.cs
@@ -1,0 +1,175 @@
+using LeanCode.DomainModels.Generators;
+using Microsoft.CodeAnalysis;
+using Xunit;
+using TypedIdFormat = LeanCode.DomainModels.Generators.TypedIdFormat;
+
+namespace LeanCode.DomainModels.Tests.Generators;
+
+public class TypedIdDataTests
+{
+    [Fact]
+    public void Equality_returns_true_when_all_properties_match()
+    {
+        var data1 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId",
+            null,
+            false,
+            null,
+            true,
+            null
+        );
+
+        var data2 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId",
+            null,
+            false,
+            null,
+            true,
+            null
+        );
+
+        Assert.Equal(data1, data2);
+        Assert.True(data1 == data2);
+        Assert.False(data1 != data2);
+    }
+
+    [Fact]
+    public void Equality_returns_false_when_format_differs()
+    {
+        var data1 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId",
+            null,
+            false,
+            null,
+            true,
+            null
+        );
+
+        var data2 = new TypedIdData(TypedIdFormat.RawGuid, "Test.Namespace", "TestId", null, false, null, true, null);
+
+        Assert.NotEqual(data1, data2);
+        Assert.False(data1 == data2);
+        Assert.True(data1 != data2);
+    }
+
+    [Fact]
+    public void Equality_returns_false_when_namespace_differs()
+    {
+        var data1 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace1",
+            "TestId",
+            null,
+            false,
+            null,
+            true,
+            null
+        );
+
+        var data2 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace2",
+            "TestId",
+            null,
+            false,
+            null,
+            true,
+            null
+        );
+
+        Assert.NotEqual(data1, data2);
+    }
+
+    [Fact]
+    public void Equality_returns_false_when_type_name_differs()
+    {
+        var data1 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId1",
+            null,
+            false,
+            null,
+            true,
+            null
+        );
+
+        var data2 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId2",
+            null,
+            false,
+            null,
+            true,
+            null
+        );
+
+        Assert.NotEqual(data1, data2);
+    }
+
+    [Fact]
+    public void Equality_ignores_location_property()
+    {
+        var location1 = Location.None;
+        var location2 = Location.Create("test.cs", default, default);
+
+        var data1 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId",
+            null,
+            false,
+            null,
+            true,
+            location1
+        );
+
+        var data2 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId",
+            null,
+            false,
+            null,
+            true,
+            location2
+        );
+
+        Assert.Equal(data1, data2);
+    }
+
+    [Fact]
+    public void GetHashCode_returns_same_value_for_equal_instances()
+    {
+        var data1 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId",
+            "custom_",
+            true,
+            100,
+            true,
+            null
+        );
+
+        var data2 = new TypedIdData(
+            TypedIdFormat.PrefixedGuid,
+            "Test.Namespace",
+            "TestId",
+            "custom_",
+            true,
+            100,
+            true,
+            null
+        );
+
+        Assert.Equal(data1.GetHashCode(), data2.GetHashCode());
+    }
+}


### PR DESCRIPTION
TIL something about source generators:

### Problem
The `TypedIdData` class used reference equality, causing the incremental source generator to regenerate typed ID code on every file modification - even when the ID declaration itself hadn't changed. This was particularly impactful when ID types live in the same file as their related entities (e.g., UserId in User.cs), as any edit to the entity would trigger unnecessary regeneration, possibly burdening our poor IDE analyzers.

See: https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.md#caching