### PR TITLE
[CORELIB-392] RelationalTypeMapping for typed ids

### DIFF
--- a/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using LeanCode.DomainModels.Ids;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -9,7 +10,7 @@ public static class DbContextOptionsBuilderExtensions
 {
     /// <summary>
     /// Automatically registers TypeMappingPlugin for all TypedIds.
-    /// Supports types implementing IPrefixedTypedId and IRawTypedId with any backing type (int, long, Guid).
+    /// Supports types implementing <see cref="IPrefixedTypedId{TSelf}"/>, <see cref="IRawStringTypedId{TSelf}"/> and <see cref="IRawTypedId{TBacking,TSelf}"/> with any backing type (int, long, Guid).
     /// </summary>
     public static DbContextOptionsBuilder AddPostgresTypedIdMappingPlugins(this DbContextOptionsBuilder builder)
     {
@@ -22,7 +23,7 @@ public static class DbContextOptionsBuilderExtensions
 
     /// <summary>
     /// Automatically registers TypeMappingPlugin for all TypedIds.
-    /// Supports types implementing IPrefixedTypedId and IRawTypedId with any backing type (int, long, Guid).
+    /// Supports types implementing <see cref="IPrefixedTypedId{TSelf}"/>, <see cref="IRawStringTypedId{TSelf}"/> and <see cref="IRawTypedId{TBacking,TSelf}"/> with any backing type (int, long, Guid).
     /// </summary>
     public static DbContextOptionsBuilder AddSqlServerTypedIdMappingPlugins(this DbContextOptionsBuilder builder)
     {

--- a/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,167 @@
+using System.Reflection;
+using LeanCode.DomainModels.Ids;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LeanCode.DomainModels.EF;
+
+public static class DbContextOptionsBuilderExtensions
+{
+    private static readonly MethodInfo AddPrefixedTypedIdPluginMethod =
+        typeof(DbContextOptionsBuilderExtensions).GetMethod(nameof(AddPrefixedTypedIdPlugin))!;
+
+    private static readonly MethodInfo AddRawTypedIdPluginMethod = typeof(DbContextOptionsBuilderExtensions).GetMethod(
+        nameof(AddRawTypedIdPlugin)
+    )!;
+
+    /// <summary>
+    /// Automatically registers TypeMappingPlugins for all TypedIds found in the specified assemblies.
+    /// Scans for types implementing IPrefixedTypedId and IRawTypedId with any backing type (int, long, Guid).
+    /// </summary>
+    public static DbContextOptionsBuilder AddAllTypedIdPlugins(
+        this DbContextOptionsBuilder builder,
+        params Assembly[] assemblies
+    )
+    {
+        foreach (var assembly in assemblies)
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                if (type.IsAbstract)
+                {
+                    continue;
+                }
+
+                if (IsPrefixedTypedId(type))
+                {
+                    var method = AddPrefixedTypedIdPluginMethod.MakeGenericMethod(type);
+                    method.Invoke(null, [builder]);
+                }
+                else if (TryGetRawTypedIdBackingType(type, out var backingType))
+                {
+                    var method = AddRawTypedIdPluginMethod.MakeGenericMethod(backingType, type);
+                    method.Invoke(null, [builder]);
+                }
+            }
+        }
+
+        return builder;
+    }
+
+    public static DbContextOptionsBuilder AddPrefixedTypedIdPlugin<TId>(this DbContextOptionsBuilder builder)
+        where TId : struct, IPrefixedTypedId<TId>
+    {
+        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(
+            new PrefixedTypedIdDbContextOptionsExtension<TId>()
+        );
+
+        return builder;
+    }
+
+    public static DbContextOptionsBuilder AddRawTypedIdPlugin<TBacking, TId>(this DbContextOptionsBuilder builder)
+        where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
+        where TId : struct, IRawTypedId<TBacking, TId>
+    {
+        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(
+            new RawTypedIdDbContextOptionsExtension<TBacking, TId>()
+        );
+
+        return builder;
+    }
+
+    private static bool IsPrefixedTypedId(Type type)
+    {
+        return type.GetInterfaces()
+            .Any(i =>
+                i.IsGenericType
+                && i.GetGenericTypeDefinition() == typeof(IPrefixedTypedId<>)
+                && i.GetGenericArguments()[0] == type
+            );
+    }
+
+    private static bool TryGetRawTypedIdBackingType(Type type, out Type backingType)
+    {
+        var rawTypedIdInterface = type.GetInterfaces()
+            .FirstOrDefault(i =>
+                i.IsGenericType
+                && i.GetGenericTypeDefinition() == typeof(IRawTypedId<,>)
+                && i.GetGenericArguments()[1] == type
+            );
+
+        if (rawTypedIdInterface != null)
+        {
+            backingType = rawTypedIdInterface.GetGenericArguments()[0];
+            return true;
+        }
+
+        backingType = null!;
+        return false;
+    }
+}
+
+internal class PrefixedTypedIdDbContextOptionsExtension<TId> : IDbContextOptionsExtension
+    where TId : struct, IPrefixedTypedId<TId>
+{
+    public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
+
+    public void ApplyServices(IServiceCollection services)
+    {
+        services.AddSingleton<IRelationalTypeMappingSourcePlugin, PrefixedTypedIdTypeMappingPlugin<TId>>();
+    }
+
+    public void Validate(IDbContextOptions options) { }
+
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
+    {
+        public override bool IsDatabaseProvider => false;
+
+        public override string LogFragment => $"PrefixedTypedIdPlugin<{typeof(TId).Name}>";
+
+        public override int GetServiceProviderHashCode() => typeof(TId).GetHashCode();
+
+        public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+        {
+            return other is ExtensionInfo otherExtension && otherExtension.Extension.GetType() == Extension.GetType();
+        }
+
+        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+        {
+            debugInfo[$"PrefixedTypedId:{typeof(TId).Name}"] = "1";
+        }
+    }
+}
+
+internal class RawTypedIdDbContextOptionsExtension<TBacking, TId> : IDbContextOptionsExtension
+    where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
+    where TId : struct, IRawTypedId<TBacking, TId>
+{
+    public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
+
+    public void ApplyServices(IServiceCollection services)
+    {
+        services.AddSingleton<IRelationalTypeMappingSourcePlugin, RawTypedIdTypeMappingPlugin<TBacking, TId>>();
+    }
+
+    public void Validate(IDbContextOptions options) { }
+
+    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
+    {
+        public override bool IsDatabaseProvider => false;
+
+        public override string LogFragment => $"RawTypedIdPlugin<{typeof(TBacking).Name}, {typeof(TId).Name}>";
+
+        public override int GetServiceProviderHashCode() => HashCode.Combine(typeof(TBacking), typeof(TId));
+
+        public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+        {
+            return other is ExtensionInfo otherExtension && otherExtension.Extension.GetType() == Extension.GetType();
+        }
+
+        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+        {
+            debugInfo[$"RawTypedId<{typeof(TBacking).Name}>:{typeof(TId).Name}"] = "1";
+        }
+    }
+}

--- a/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
@@ -11,9 +11,24 @@ public static class DbContextOptionsBuilderExtensions
     /// Automatically registers TypeMappingPlugin for all TypedIds.
     /// Supports types implementing IPrefixedTypedId and IRawTypedId with any backing type (int, long, Guid).
     /// </summary>
-    public static DbContextOptionsBuilder AddAllTypedIdPlugins(this DbContextOptionsBuilder builder)
+    public static DbContextOptionsBuilder AddPostgresTypedIdMappingPlugins(this DbContextOptionsBuilder builder)
     {
-        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(new TypedIdDbContextOptionsExtension());
+        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(
+            new TypedIdDbContextOptionsExtension(new PostgresTypedIdStoreTypeProvider())
+        );
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Automatically registers TypeMappingPlugin for all TypedIds.
+    /// Supports types implementing IPrefixedTypedId and IRawTypedId with any backing type (int, long, Guid).
+    /// </summary>
+    public static DbContextOptionsBuilder AddSqlServerTypedIdMappingPlugins(this DbContextOptionsBuilder builder)
+    {
+        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(
+            new TypedIdDbContextOptionsExtension(new SqlServerTypedIdStoreTypeProvider())
+        );
 
         return builder;
     }
@@ -21,11 +36,20 @@ public static class DbContextOptionsBuilderExtensions
 
 internal class TypedIdDbContextOptionsExtension : IDbContextOptionsExtension
 {
+    private readonly ITypedIdStoreTypeProvider storeTypeProvider;
+
+    public TypedIdDbContextOptionsExtension(ITypedIdStoreTypeProvider storeTypeProvider)
+    {
+        this.storeTypeProvider = storeTypeProvider;
+    }
+
     public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
 
     public void ApplyServices(IServiceCollection services)
     {
-        services.AddSingleton<IRelationalTypeMappingSourcePlugin, TypedIdTypeMappingSourcePlugin>();
+        services.AddSingleton<IRelationalTypeMappingSourcePlugin>(
+            new TypedIdTypeMappingSourcePlugin(storeTypeProvider)
+        );
     }
 
     public void Validate(IDbContextOptions options) { }

--- a/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/DbContextOptionsBuilderExtensions.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using LeanCode.DomainModels.Ids;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -9,106 +7,25 @@ namespace LeanCode.DomainModels.EF;
 
 public static class DbContextOptionsBuilderExtensions
 {
-    private static readonly MethodInfo AddPrefixedTypedIdPluginMethod =
-        typeof(DbContextOptionsBuilderExtensions).GetMethod(nameof(AddPrefixedTypedIdPlugin))!;
-
-    private static readonly MethodInfo AddRawTypedIdPluginMethod = typeof(DbContextOptionsBuilderExtensions).GetMethod(
-        nameof(AddRawTypedIdPlugin)
-    )!;
-
     /// <summary>
-    /// Automatically registers TypeMappingPlugins for all TypedIds found in the specified assemblies.
-    /// Scans for types implementing IPrefixedTypedId and IRawTypedId with any backing type (int, long, Guid).
+    /// Automatically registers TypeMappingPlugin for all TypedIds.
+    /// Supports types implementing IPrefixedTypedId and IRawTypedId with any backing type (int, long, Guid).
     /// </summary>
-    public static DbContextOptionsBuilder AddAllTypedIdPlugins(
-        this DbContextOptionsBuilder builder,
-        params Assembly[] assemblies
-    )
+    public static DbContextOptionsBuilder AddAllTypedIdPlugins(this DbContextOptionsBuilder builder)
     {
-        foreach (var assembly in assemblies)
-        {
-            foreach (var type in assembly.GetTypes())
-            {
-                if (type.IsAbstract)
-                {
-                    continue;
-                }
-
-                if (IsPrefixedTypedId(type))
-                {
-                    var method = AddPrefixedTypedIdPluginMethod.MakeGenericMethod(type);
-                    method.Invoke(null, [builder]);
-                }
-                else if (TryGetRawTypedIdBackingType(type, out var backingType))
-                {
-                    var method = AddRawTypedIdPluginMethod.MakeGenericMethod(backingType, type);
-                    method.Invoke(null, [builder]);
-                }
-            }
-        }
+        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(new TypedIdDbContextOptionsExtension());
 
         return builder;
-    }
-
-    public static DbContextOptionsBuilder AddPrefixedTypedIdPlugin<TId>(this DbContextOptionsBuilder builder)
-        where TId : struct, IPrefixedTypedId<TId>
-    {
-        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(
-            new PrefixedTypedIdDbContextOptionsExtension<TId>()
-        );
-
-        return builder;
-    }
-
-    public static DbContextOptionsBuilder AddRawTypedIdPlugin<TBacking, TId>(this DbContextOptionsBuilder builder)
-        where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
-        where TId : struct, IRawTypedId<TBacking, TId>
-    {
-        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(
-            new RawTypedIdDbContextOptionsExtension<TBacking, TId>()
-        );
-
-        return builder;
-    }
-
-    private static bool IsPrefixedTypedId(Type type)
-    {
-        return type.GetInterfaces()
-            .Any(i =>
-                i.IsGenericType
-                && i.GetGenericTypeDefinition() == typeof(IPrefixedTypedId<>)
-                && i.GetGenericArguments()[0] == type
-            );
-    }
-
-    private static bool TryGetRawTypedIdBackingType(Type type, out Type backingType)
-    {
-        var rawTypedIdInterface = type.GetInterfaces()
-            .FirstOrDefault(i =>
-                i.IsGenericType
-                && i.GetGenericTypeDefinition() == typeof(IRawTypedId<,>)
-                && i.GetGenericArguments()[1] == type
-            );
-
-        if (rawTypedIdInterface != null)
-        {
-            backingType = rawTypedIdInterface.GetGenericArguments()[0];
-            return true;
-        }
-
-        backingType = null!;
-        return false;
     }
 }
 
-internal class PrefixedTypedIdDbContextOptionsExtension<TId> : IDbContextOptionsExtension
-    where TId : struct, IPrefixedTypedId<TId>
+internal class TypedIdDbContextOptionsExtension : IDbContextOptionsExtension
 {
     public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
 
     public void ApplyServices(IServiceCollection services)
     {
-        services.AddSingleton<IRelationalTypeMappingSourcePlugin, PrefixedTypedIdTypeMappingPlugin<TId>>();
+        services.AddSingleton<IRelationalTypeMappingSourcePlugin, TypedIdTypeMappingSourcePlugin>();
     }
 
     public void Validate(IDbContextOptions options) { }
@@ -117,51 +34,18 @@ internal class PrefixedTypedIdDbContextOptionsExtension<TId> : IDbContextOptions
     {
         public override bool IsDatabaseProvider => false;
 
-        public override string LogFragment => $"PrefixedTypedIdPlugin<{typeof(TId).Name}>";
+        public override string LogFragment => "TypedIdPlugin";
 
-        public override int GetServiceProviderHashCode() => typeof(TId).GetHashCode();
+        public override int GetServiceProviderHashCode() => 0;
 
         public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
         {
-            return other is ExtensionInfo otherExtension && otherExtension.Extension.GetType() == Extension.GetType();
+            return other is ExtensionInfo;
         }
 
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
         {
-            debugInfo[$"PrefixedTypedId:{typeof(TId).Name}"] = "1";
-        }
-    }
-}
-
-internal class RawTypedIdDbContextOptionsExtension<TBacking, TId> : IDbContextOptionsExtension
-    where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
-    where TId : struct, IRawTypedId<TBacking, TId>
-{
-    public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
-
-    public void ApplyServices(IServiceCollection services)
-    {
-        services.AddSingleton<IRelationalTypeMappingSourcePlugin, RawTypedIdTypeMappingPlugin<TBacking, TId>>();
-    }
-
-    public void Validate(IDbContextOptions options) { }
-
-    private sealed class ExtensionInfo(IDbContextOptionsExtension extension) : DbContextOptionsExtensionInfo(extension)
-    {
-        public override bool IsDatabaseProvider => false;
-
-        public override string LogFragment => $"RawTypedIdPlugin<{typeof(TBacking).Name}, {typeof(TId).Name}>";
-
-        public override int GetServiceProviderHashCode() => HashCode.Combine(typeof(TBacking), typeof(TId));
-
-        public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
-        {
-            return other is ExtensionInfo otherExtension && otherExtension.Extension.GetType() == Extension.GetType();
-        }
-
-        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
-        {
-            debugInfo[$"RawTypedId<{typeof(TBacking).Name}>:{typeof(TId).Name}"] = "1";
+            debugInfo["TypedId:Enabled"] = "1";
         }
     }
 }

--- a/src/Domain/LeanCode.DomainModels.EF/ModelConfigurationBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/ModelConfigurationBuilderExtensions.cs
@@ -83,6 +83,9 @@ public static class ModelConfigurationBuilderExtensions
             });
     }
 
+    /// <summary>
+    /// Registers conventions for all types <see cref="IPrefixedTypedId{TSelf}"/>, <see cref="IRawStringTypedId{TSelf}"/> and <see cref="IRawTypedId{TBacking,TSelf}"/> defined in the assemblies.
+    /// </summary>
     public static ModelConfigurationBuilder ConfigureTypedIdsConventions(
         this ModelConfigurationBuilder configurationBuilder,
         params Assembly[] assemblies

--- a/src/Domain/LeanCode.DomainModels.EF/ModelConfigurationBuilderExtensions.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/ModelConfigurationBuilderExtensions.cs
@@ -1,0 +1,184 @@
+using System.Reflection;
+using LeanCode.DomainModels.Ids;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LeanCode.DomainModels.EF;
+
+public static class ModelConfigurationBuilderExtensions
+{
+    private static readonly MethodInfo AreIntTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreIntTypedId),
+        nullable: false
+    );
+    private static readonly MethodInfo AreLongTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreLongTypedId),
+        nullable: false
+    );
+    private static readonly MethodInfo AreGuidTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreGuidTypedId),
+        nullable: false
+    );
+    private static readonly MethodInfo AreStringTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreStringTypedId),
+        nullable: false
+    );
+    private static readonly MethodInfo ArePrefixedTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.ArePrefixedTypedId),
+        nullable: false
+    );
+
+    private static readonly MethodInfo AreNullableIntTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreIntTypedId),
+        nullable: true
+    );
+    private static readonly MethodInfo AreNullableLongTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreLongTypedId),
+        nullable: true
+    );
+    private static readonly MethodInfo AreNullableGuidTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreGuidTypedId),
+        nullable: true
+    );
+    private static readonly MethodInfo AreNullableStringTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.AreStringTypedId),
+        nullable: true
+    );
+    private static readonly MethodInfo AreNullablePrefixedTypedIdMethod = GetAreTypedIdMethod(
+        nameof(PropertiesConfigurationBuilderExtensions.ArePrefixedTypedId),
+        nullable: true
+    );
+
+    private static MethodInfo GetAreTypedIdMethod(string name, bool nullable)
+    {
+        return typeof(PropertiesConfigurationBuilderExtensions)
+            .GetMethods()
+            .First(m =>
+            {
+                if (m.Name != name)
+                {
+                    return false;
+                }
+
+                var parameters = m.GetParameters();
+                if (parameters.Length != 1)
+                {
+                    return false;
+                }
+
+                var parameterType = parameters[0].ParameterType;
+                if (
+                    !parameterType.IsGenericType
+                    || parameterType.GetGenericTypeDefinition() != typeof(PropertiesConfigurationBuilder<>)
+                )
+                {
+                    return false;
+                }
+
+                var genericArgument = parameterType.GetGenericArguments()[0];
+                var isNullable =
+                    genericArgument.IsGenericType && genericArgument.GetGenericTypeDefinition() == typeof(Nullable<>);
+
+                return isNullable == nullable;
+            });
+    }
+
+    public static ModelConfigurationBuilder ConfigureTypedIdsConventions(
+        this ModelConfigurationBuilder configurationBuilder,
+        params Assembly[] assemblies
+    )
+    {
+        foreach (var assembly in assemblies)
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                if (type.IsAbstract || !type.IsValueType)
+                {
+                    continue;
+                }
+
+                foreach (var iface in type.GetInterfaces())
+                {
+                    if (iface.IsGenericType)
+                    {
+                        var genericDefinition = iface.GetGenericTypeDefinition();
+                        if (genericDefinition == typeof(IPrefixedTypedId<>) && iface.GetGenericArguments()[0] == type)
+                        {
+                            Configure(
+                                configurationBuilder,
+                                type,
+                                ArePrefixedTypedIdMethod,
+                                AreNullablePrefixedTypedIdMethod
+                            );
+                        }
+                        else if (genericDefinition == typeof(IRawTypedId<,>) && iface.GetGenericArguments()[1] == type)
+                        {
+                            var backingType = iface.GetGenericArguments()[0];
+                            if (backingType == typeof(int))
+                            {
+                                Configure(configurationBuilder, type, AreIntTypedIdMethod, AreNullableIntTypedIdMethod);
+                            }
+                            else if (backingType == typeof(long))
+                            {
+                                Configure(
+                                    configurationBuilder,
+                                    type,
+                                    AreLongTypedIdMethod,
+                                    AreNullableLongTypedIdMethod
+                                );
+                            }
+                            else if (backingType == typeof(Guid))
+                            {
+                                Configure(
+                                    configurationBuilder,
+                                    type,
+                                    AreGuidTypedIdMethod,
+                                    AreNullableGuidTypedIdMethod
+                                );
+                            }
+                        }
+                        else if (
+                            genericDefinition == typeof(IRawStringTypedId<>)
+                            && iface.GetGenericArguments()[0] == type
+                        )
+                        {
+                            Configure(
+                                configurationBuilder,
+                                type,
+                                AreStringTypedIdMethod,
+                                AreNullableStringTypedIdMethod
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        return configurationBuilder;
+    }
+
+    private static void Configure(
+        ModelConfigurationBuilder configurationBuilder,
+        Type type,
+        MethodInfo method,
+        MethodInfo nullableMethod
+    )
+    {
+        var propertiesMethod = typeof(ModelConfigurationBuilder).GetMethod(
+            nameof(ModelConfigurationBuilder.Properties),
+            BindingFlags.Public | BindingFlags.Instance,
+            []
+        )!;
+
+        // Configure non-nullable
+        var propertiesBuilder = propertiesMethod.MakeGenericMethod(type).Invoke(configurationBuilder, null);
+        method.MakeGenericMethod(type).Invoke(null, [propertiesBuilder]);
+
+        // Configure nullable
+        var nullableType = typeof(Nullable<>).MakeGenericType(type);
+        var nullablePropertiesBuilder = propertiesMethod
+            .MakeGenericMethod(nullableType)
+            .Invoke(configurationBuilder, null);
+        nullableMethod.MakeGenericMethod(type).Invoke(null, [nullablePropertiesBuilder]);
+    }
+}

--- a/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
@@ -1,61 +1,33 @@
 using LeanCode.DomainModels.Ids;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace LeanCode.DomainModels.EF;
 
-/// <summary>
-/// Generic type mapping for PrefixedTypedId (PrefixedGuid and PrefixedUlid).
-/// Maps to PostgreSQL citext type.
-/// </summary>
-public class PrefixedTypedIdTypeMapping<TId> : RelationalTypeMapping
-    where TId : struct, IPrefixedTypedId<TId>
+public interface ITypedIdStoreTypeProvider
 {
-    private static readonly PrefixedTypedIdConverter<TId> ValueConverter = new();
+    string PrefixedStoreType<TId>()
+        where TId : struct, IPrefixedTypedId<TId>;
 
-    public PrefixedTypedIdTypeMapping()
-        : base(
-            new RelationalTypeMappingParameters(new CoreTypeMappingParameters(typeof(TId), ValueConverter), "citext")
-        ) { }
+    string RawStringStoreType<TId>()
+        where TId : struct, IRawStringTypedId<TId>;
 
-    protected PrefixedTypedIdTypeMapping(RelationalTypeMappingParameters parameters)
-        : base(parameters) { }
-
-    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-    {
-        return new PrefixedTypedIdTypeMapping<TId>(parameters);
-    }
+    string RawStoreType<TId, TBacking>()
+        where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
+        where TId : struct, IRawTypedId<TBacking, TId>;
 }
 
-/// <summary>
-/// Generic type mapping for RawTypedId with any backing type.
-/// Automatically determines the correct PostgreSQL type based on the backing type.
-/// </summary>
-public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
-    where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
-    where TId : struct, IRawTypedId<TBacking, TId>
+public class PostgresTypedIdStoreTypeProvider : ITypedIdStoreTypeProvider
 {
-    private static readonly ValueConverter<TId, TBacking> ValueConverter = new(id => id.Value, TId.FromDatabase);
-    private static readonly ValueComparer<TId> ValueComparer = new(TId.DatabaseEquals, d => d.GetHashCode());
+    public string PrefixedStoreType<TId>()
+        where TId : struct, IPrefixedTypedId<TId> => "citext";
 
-    public RawTypedIdTypeMapping()
-        : base(
-            new RelationalTypeMappingParameters(
-                new CoreTypeMappingParameters(typeof(TId), ValueConverter, ValueComparer),
-                GetStoreType()
-            )
-        ) { }
+    public string RawStringStoreType<TId>()
+        where TId : struct, IRawStringTypedId<TId> => "citext";
 
-    protected RawTypedIdTypeMapping(RelationalTypeMappingParameters parameters)
-        : base(parameters) { }
-
-    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
-    {
-        return new RawTypedIdTypeMapping<TBacking, TId>(parameters);
-    }
-
-    private static string GetStoreType()
+    public string RawStoreType<TId, TBacking>()
+        where TId : struct, IRawTypedId<TBacking, TId>
+        where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
     {
         return typeof(TBacking) switch
         {
@@ -69,8 +41,90 @@ public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
     }
 }
 
+public class SqlServerTypedIdStoreTypeProvider : ITypedIdStoreTypeProvider
+{
+    public string PrefixedStoreType<TId>()
+        where TId : struct, IPrefixedTypedId<TId> => $"nchar({TId.MaxLength})";
+
+    public string RawStringStoreType<TId>()
+        where TId : struct, IRawStringTypedId<TId> => $"nvarchar({TId.MaxLength})";
+
+    public string RawStoreType<TId, TBacking>()
+        where TId : struct, IRawTypedId<TBacking, TId>
+        where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
+    {
+        return typeof(TBacking) switch
+        {
+            Type t when t == typeof(int) => "int",
+            Type t when t == typeof(long) => "bigint",
+            Type t when t == typeof(Guid) => "uniqueidentifier",
+            _ => throw new NotSupportedException(
+                $"Backing type {typeof(TBacking).Name} is not supported for RawTypedId."
+            ),
+        };
+    }
+}
+
+/// <summary>
+/// Generic type mapping for PrefixedTypedId (PrefixedGuid and PrefixedUlid).
+/// </summary>
+public class PrefixedTypedIdTypeMapping<TId> : RelationalTypeMapping
+    where TId : struct, IPrefixedTypedId<TId>
+{
+    private static readonly PrefixedTypedIdConverter<TId> ValueConverter = new();
+
+    public PrefixedTypedIdTypeMapping(ITypedIdStoreTypeProvider storeTypeProvider)
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(TId), ValueConverter),
+                storeTypeProvider.PrefixedStoreType<TId>()
+            )
+        ) { }
+
+    protected PrefixedTypedIdTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters) { }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+    {
+        return new PrefixedTypedIdTypeMapping<TId>(parameters);
+    }
+}
+
+/// <summary>
+/// Generic type mapping for RawTypedId with any backing type.
+/// </summary>
+public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
+    where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
+    where TId : struct, IRawTypedId<TBacking, TId>
+{
+    private static readonly ValueConverter<TId, TBacking> ValueConverter = new(id => id.Value, TId.FromDatabase);
+
+    public RawTypedIdTypeMapping(ITypedIdStoreTypeProvider storeTypeProvider)
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(TId), ValueConverter),
+                storeTypeProvider.RawStoreType<TId, TBacking>()
+            )
+        ) { }
+
+    protected RawTypedIdTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters) { }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+    {
+        return new RawTypedIdTypeMapping<TBacking, TId>(parameters);
+    }
+}
+
 public class TypedIdTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
 {
+    private readonly ITypedIdStoreTypeProvider storeTypeProvider;
+
+    public TypedIdTypeMappingSourcePlugin(ITypedIdStoreTypeProvider storeTypeProvider)
+    {
+        this.storeTypeProvider = storeTypeProvider;
+    }
+
     public RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
     {
         var type = mappingInfo.ClrType;
@@ -80,11 +134,6 @@ public class TypedIdTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
             return null;
         }
 
-        return CreateMapping(type);
-    }
-
-    private static RelationalTypeMapping? CreateMapping(Type type)
-    {
         if (type.IsAbstract || !type.IsValueType)
         {
             return null;
@@ -98,13 +147,13 @@ public class TypedIdTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
                 if (genericDefinition == typeof(IPrefixedTypedId<>) && iface.GetGenericArguments()[0] == type)
                 {
                     var mappingType = typeof(PrefixedTypedIdTypeMapping<>).MakeGenericType(type);
-                    return (RelationalTypeMapping)Activator.CreateInstance(mappingType)!;
+                    return (RelationalTypeMapping)Activator.CreateInstance(mappingType, storeTypeProvider)!;
                 }
                 else if (genericDefinition == typeof(IRawTypedId<,>) && iface.GetGenericArguments()[1] == type)
                 {
                     var backingType = iface.GetGenericArguments()[0];
                     var mappingType = typeof(RawTypedIdTypeMapping<,>).MakeGenericType(backingType, type);
-                    return (RelationalTypeMapping)Activator.CreateInstance(mappingType)!;
+                    return (RelationalTypeMapping)Activator.CreateInstance(mappingType, storeTypeProvider)!;
                 }
             }
         }

--- a/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
@@ -1,0 +1,99 @@
+using LeanCode.DomainModels.Ids;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace LeanCode.DomainModels.EF;
+
+/// <summary>
+/// Generic type mapping for PrefixedTypedId (PrefixedGuid and PrefixedUlid).
+/// Maps to PostgreSQL citext type.
+/// </summary>
+public class PrefixedTypedIdTypeMapping<TId> : RelationalTypeMapping
+    where TId : struct, IPrefixedTypedId<TId>
+{
+    private static readonly PrefixedTypedIdConverter<TId> ValueConverter = new();
+
+    public PrefixedTypedIdTypeMapping()
+        : base(
+            new RelationalTypeMappingParameters(new CoreTypeMappingParameters(typeof(TId), ValueConverter), "citext")
+        ) { }
+
+    protected PrefixedTypedIdTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters) { }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+    {
+        return new PrefixedTypedIdTypeMapping<TId>(parameters);
+    }
+}
+
+/// <summary>
+/// Generic type mapping for RawTypedId with any backing type.
+/// Automatically determines the correct PostgreSQL type based on the backing type.
+/// </summary>
+public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
+    where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
+    where TId : struct, IRawTypedId<TBacking, TId>
+{
+    private static readonly ValueConverter<TId, TBacking> ValueConverter = new(id => id.Value, TId.FromDatabase);
+    private static readonly ValueComparer<TId> ValueComparer = new(TId.DatabaseEquals, d => d.GetHashCode());
+
+    public RawTypedIdTypeMapping()
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(TId), ValueConverter, ValueComparer),
+                GetStoreType()
+            )
+        ) { }
+
+    protected RawTypedIdTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters) { }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+    {
+        return new RawTypedIdTypeMapping<TBacking, TId>(parameters);
+    }
+
+    private static string GetStoreType()
+    {
+        return typeof(TBacking) switch
+        {
+            Type t when t == typeof(int) => "integer",
+            Type t when t == typeof(long) => "bigint",
+            Type t when t == typeof(Guid) => "uuid",
+            _ => throw new NotSupportedException(
+                $"Backing type {typeof(TBacking).Name} is not supported for RawTypedId."
+            ),
+        };
+    }
+}
+
+public class PrefixedTypedIdTypeMappingPlugin<TId> : IRelationalTypeMappingSourcePlugin
+    where TId : struct, IPrefixedTypedId<TId>
+{
+    public RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
+    {
+        if (mappingInfo.ClrType == typeof(TId))
+        {
+            return new PrefixedTypedIdTypeMapping<TId>();
+        }
+
+        return null;
+    }
+}
+
+public class RawTypedIdTypeMappingPlugin<TBacking, TId> : IRelationalTypeMappingSourcePlugin
+    where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
+    where TId : struct, IRawTypedId<TBacking, TId>
+{
+    public RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
+    {
+        if (mappingInfo.ClrType == typeof(TId))
+        {
+            return new RawTypedIdTypeMapping<TBacking, TId>();
+        }
+
+        return null;
+    }
+}

--- a/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
@@ -116,9 +116,35 @@ public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
     }
 }
 
+/// <summary>
+/// Generic type mapping for RawStringTypedId.
+/// </summary>
+public class RawStringTypedIdTypeMapping<TId> : RelationalTypeMapping
+    where TId : struct, IRawStringTypedId<TId>
+{
+    private static readonly RawStringTypedIdConverter<TId> ValueConverter = new();
+
+    public RawStringTypedIdTypeMapping(ITypedIdStoreTypeProvider storeTypeProvider)
+        : base(
+            new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(typeof(TId), ValueConverter),
+                storeTypeProvider.RawStringStoreType<TId>()
+            )
+        ) { }
+
+    protected RawStringTypedIdTypeMapping(RelationalTypeMappingParameters parameters)
+        : base(parameters) { }
+
+    protected override RelationalTypeMapping Clone(RelationalTypeMappingParameters parameters)
+    {
+        return new RawStringTypedIdTypeMapping<TId>(parameters);
+    }
+}
+
 public class TypedIdTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
 {
     private readonly ITypedIdStoreTypeProvider storeTypeProvider;
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Type, RelationalTypeMapping?> cache = new();
 
     public TypedIdTypeMappingSourcePlugin(ITypedIdStoreTypeProvider storeTypeProvider)
     {
@@ -153,6 +179,11 @@ public class TypedIdTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
                 {
                     var backingType = iface.GetGenericArguments()[0];
                     var mappingType = typeof(RawTypedIdTypeMapping<,>).MakeGenericType(backingType, type);
+                    return (RelationalTypeMapping)Activator.CreateInstance(mappingType, storeTypeProvider)!;
+                }
+                else if (genericDefinition == typeof(IRawStringTypedId<>) && iface.GetGenericArguments()[0] == type)
+                {
+                    var mappingType = typeof(RawStringTypedIdTypeMapping<>).MakeGenericType(type);
                     return (RelationalTypeMapping)Activator.CreateInstance(mappingType, storeTypeProvider)!;
                 }
             }

--- a/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
@@ -69,29 +69,44 @@ public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
     }
 }
 
-public class PrefixedTypedIdTypeMappingPlugin<TId> : IRelationalTypeMappingSourcePlugin
-    where TId : struct, IPrefixedTypedId<TId>
+public class TypedIdTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
 {
     public RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
     {
-        if (mappingInfo.ClrType == typeof(TId))
+        var type = mappingInfo.ClrType;
+
+        if (type == null)
         {
-            return new PrefixedTypedIdTypeMapping<TId>();
+            return null;
         }
 
-        return null;
+        return CreateMapping(type);
     }
-}
 
-public class RawTypedIdTypeMappingPlugin<TBacking, TId> : IRelationalTypeMappingSourcePlugin
-    where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
-    where TId : struct, IRawTypedId<TBacking, TId>
-{
-    public RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
+    private static RelationalTypeMapping? CreateMapping(Type type)
     {
-        if (mappingInfo.ClrType == typeof(TId))
+        if (type.IsAbstract || !type.IsValueType)
         {
-            return new RawTypedIdTypeMapping<TBacking, TId>();
+            return null;
+        }
+
+        foreach (var iface in type.GetInterfaces())
+        {
+            if (iface.IsGenericType)
+            {
+                var genericDefinition = iface.GetGenericTypeDefinition();
+                if (genericDefinition == typeof(IPrefixedTypedId<>) && iface.GetGenericArguments()[0] == type)
+                {
+                    var mappingType = typeof(PrefixedTypedIdTypeMapping<>).MakeGenericType(type);
+                    return (RelationalTypeMapping)Activator.CreateInstance(mappingType)!;
+                }
+                else if (genericDefinition == typeof(IRawTypedId<,>) && iface.GetGenericArguments()[1] == type)
+                {
+                    var backingType = iface.GetGenericArguments()[0];
+                    var mappingType = typeof(RawTypedIdTypeMapping<,>).MakeGenericType(backingType, type);
+                    return (RelationalTypeMapping)Activator.CreateInstance(mappingType)!;
+                }
+            }
         }
 
         return null;

--- a/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
+++ b/src/Domain/LeanCode.DomainModels.EF/TypedIdTypeMappingPlugins.cs
@@ -1,6 +1,5 @@
 using LeanCode.DomainModels.Ids;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace LeanCode.DomainModels.EF;
 
@@ -71,12 +70,14 @@ public class SqlServerTypedIdStoreTypeProvider : ITypedIdStoreTypeProvider
 public class PrefixedTypedIdTypeMapping<TId> : RelationalTypeMapping
     where TId : struct, IPrefixedTypedId<TId>
 {
-    private static readonly PrefixedTypedIdConverter<TId> ValueConverter = new();
-
     public PrefixedTypedIdTypeMapping(ITypedIdStoreTypeProvider storeTypeProvider)
         : base(
             new RelationalTypeMappingParameters(
-                new CoreTypeMappingParameters(typeof(TId), ValueConverter),
+                new CoreTypeMappingParameters(
+                    typeof(TId),
+                    PrefixedTypedIdConverter<TId>.Instance,
+                    PrefixedTypedIdComparer<TId>.Instance
+                ),
                 storeTypeProvider.PrefixedStoreType<TId>()
             )
         ) { }
@@ -97,12 +98,14 @@ public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
     where TBacking : struct, IEquatable<TBacking>, IComparable<TBacking>, ISpanParsable<TBacking>
     where TId : struct, IRawTypedId<TBacking, TId>
 {
-    private static readonly ValueConverter<TId, TBacking> ValueConverter = new(id => id.Value, TId.FromDatabase);
-
     public RawTypedIdTypeMapping(ITypedIdStoreTypeProvider storeTypeProvider)
         : base(
             new RelationalTypeMappingParameters(
-                new CoreTypeMappingParameters(typeof(TId), ValueConverter),
+                new CoreTypeMappingParameters(
+                    typeof(TId),
+                    RawTypedIdConverter<TBacking, TId>.Instance,
+                    RawTypedIdComparer<TBacking, TId>.Instance
+                ),
                 storeTypeProvider.RawStoreType<TId, TBacking>()
             )
         ) { }
@@ -122,12 +125,14 @@ public class RawTypedIdTypeMapping<TBacking, TId> : RelationalTypeMapping
 public class RawStringTypedIdTypeMapping<TId> : RelationalTypeMapping
     where TId : struct, IRawStringTypedId<TId>
 {
-    private static readonly RawStringTypedIdConverter<TId> ValueConverter = new();
-
     public RawStringTypedIdTypeMapping(ITypedIdStoreTypeProvider storeTypeProvider)
         : base(
             new RelationalTypeMappingParameters(
-                new CoreTypeMappingParameters(typeof(TId), ValueConverter),
+                new CoreTypeMappingParameters(
+                    typeof(TId),
+                    RawStringTypedIdConverter<TId>.Instance,
+                    RawStringTypedIdComparer<TId>.Instance
+                ),
                 storeTypeProvider.RawStringStoreType<TId>()
             )
         ) { }
@@ -144,7 +149,6 @@ public class RawStringTypedIdTypeMapping<TId> : RelationalTypeMapping
 public class TypedIdTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
 {
     private readonly ITypedIdStoreTypeProvider storeTypeProvider;
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<Type, RelationalTypeMapping?> cache = new();
 
     public TypedIdTypeMappingSourcePlugin(ITypedIdStoreTypeProvider storeTypeProvider)
     {

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/ModelConfigurationBuilderExtensionsTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/ModelConfigurationBuilderExtensionsTests.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Xunit;
+
+namespace LeanCode.DomainModels.EF.Tests;
+
+[SuppressMessage("?", "EF1001", Justification = "Tests.")]
+public class ModelConfigurationBuilderExtensionsTests
+{
+    [Fact]
+    public void ConfigureTypedIdsConventions_registers_all_typed_ids_from_assembly()
+    {
+        var builder = new ModelConfigurationBuilderWrapper();
+        builder.ConfigureTypedIdsConventions(typeof(IntId).Assembly);
+        var model = builder.Build();
+
+        AssertRegistered<IntId, RawTypedIdConverter<int, IntId>>(model);
+        AssertRegistered<LongId, RawTypedIdConverter<long, LongId>>(model);
+        AssertRegistered<GuidId, RawTypedIdConverter<Guid, GuidId>>(model);
+        AssertRegistered<StringId, RawStringTypedIdConverter<StringId>>(model);
+        AssertRegistered<PrefixedGuidId, PrefixedTypedIdConverter<PrefixedGuidId>>(model);
+        AssertRegistered<PrefixedUlidId, PrefixedTypedIdConverter<PrefixedUlidId>>(model);
+        AssertRegistered<PrefixedStringId, PrefixedTypedIdConverter<PrefixedStringId>>(model);
+
+        AssertRegistered<IntId?, RawTypedIdConverter<int, IntId>>(model);
+        AssertRegistered<LongId?, RawTypedIdConverter<long, LongId>>(model);
+        AssertRegistered<GuidId?, RawTypedIdConverter<Guid, GuidId>>(model);
+        AssertRegistered<StringId?, RawStringTypedIdConverter<StringId>>(model);
+        AssertRegistered<PrefixedGuidId?, PrefixedTypedIdConverter<PrefixedGuidId>>(model);
+        AssertRegistered<PrefixedUlidId?, PrefixedTypedIdConverter<PrefixedUlidId>>(model);
+        AssertRegistered<PrefixedStringId?, PrefixedTypedIdConverter<PrefixedStringId>>(model);
+    }
+
+    private static void AssertRegistered<T, TConverter>(ModelConfiguration model)
+    {
+        var mapping = model.FindProperty(typeof(T));
+        Assert.NotNull(mapping);
+        Assert.IsType<TConverter>(mapping.GetValueConverter());
+    }
+}

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/TypedIdDatabaseIntegrationTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/TypedIdDatabaseIntegrationTests.cs
@@ -9,12 +9,13 @@ public class TypedIdDatabaseIntegrationTests
     [Fact]
     public void Data_is_stored_and_restored_correctly()
     {
-        Do(false);
-        Do(true);
+        Do(RegistrationMethod.Explicit);
+        Do(RegistrationMethod.ConventionManual);
+        Do(RegistrationMethod.ConventionAssemblyScan);
 
-        static void Do(bool useConventions)
+        static void Do(RegistrationMethod registrationMethod)
         {
-            using var dbContext = TestDbContext.Create(useConventions);
+            using var dbContext = TestDbContext.Create(registrationMethod);
             var a = Entity.CreateFull();
             var b = Entity.CreatePartial();
 
@@ -54,28 +55,28 @@ public class TypedIdDatabaseIntegrationTests
 
     private sealed class TestDbContext : DbContext
     {
-        private readonly bool useConventions;
+        private readonly RegistrationMethod registrationMethod;
 
         public DbSet<Entity> Entities => Set<Entity>();
 
-        public TestDbContext(bool useConventions, DbContextOptions<TestDbContext> options)
+        public TestDbContext(RegistrationMethod registrationMethod, DbContextOptions<TestDbContext> options)
             : base(options)
         {
-            this.useConventions = useConventions;
+            this.registrationMethod = registrationMethod;
         }
 
-        public static TestDbContext Create(bool useConventions)
+        public static TestDbContext Create(RegistrationMethod registrationMethod)
         {
             var options = new DbContextOptionsBuilder<TestDbContext>()
                 .UseInMemoryDatabase($"TestDb{Guid.NewGuid():N}")
                 .Options;
-            return new(useConventions, options);
+            return new(registrationMethod, options);
         }
 
         protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
         {
             base.ConfigureConventions(configurationBuilder);
-            if (useConventions)
+            if (registrationMethod == RegistrationMethod.ConventionManual)
             {
                 configurationBuilder.Properties<IntId>().AreIntTypedId();
                 configurationBuilder.Properties<LongId>().AreLongTypedId();
@@ -93,13 +94,18 @@ public class TypedIdDatabaseIntegrationTests
                 configurationBuilder.Properties<PrefixedUlidId?>().ArePrefixedTypedId();
                 configurationBuilder.Properties<PrefixedStringId?>().ArePrefixedTypedId();
             }
+
+            if (registrationMethod == RegistrationMethod.ConventionAssemblyScan)
+            {
+                configurationBuilder.ConfigureTypedIdsConventions(typeof(IntId).Assembly);
+            }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Entity>(cfg =>
             {
-                if (!useConventions)
+                if (registrationMethod == RegistrationMethod.Explicit)
                 {
                     cfg.Property(e => e.A).IsIntTypedId();
                     cfg.Property(e => e.B).IsLongTypedId();
@@ -120,6 +126,13 @@ public class TypedIdDatabaseIntegrationTests
                 cfg.HasKey(e => e.A);
             });
         }
+    }
+
+    private enum RegistrationMethod
+    {
+        Explicit,
+        ConventionManual,
+        ConventionAssemblyScan,
     }
 
     private sealed record Entity

--- a/test/Domain/LeanCode.DomainModels.EF.Tests/TypedIdTypeMappingSourcePluginTests.cs
+++ b/test/Domain/LeanCode.DomainModels.EF.Tests/TypedIdTypeMappingSourcePluginTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
+
+namespace LeanCode.DomainModels.EF.Tests;
+
+public class TypedIdTypeMappingSourcePluginTests
+{
+    private readonly TypedIdTypeMappingSourcePlugin postgresPlugin;
+    private readonly TypedIdTypeMappingSourcePlugin sqlServerPlugin;
+
+    public TypedIdTypeMappingSourcePluginTests()
+    {
+        postgresPlugin = new TypedIdTypeMappingSourcePlugin(new PostgresTypedIdStoreTypeProvider());
+        sqlServerPlugin = new TypedIdTypeMappingSourcePlugin(new SqlServerTypedIdStoreTypeProvider());
+    }
+
+    [Theory]
+    [InlineData(typeof(PrefixedGuidId), "citext", "nchar(45)")]
+    [InlineData(typeof(PrefixedUlidId), "citext", "nchar(39)")]
+    [InlineData(typeof(PrefixedStringId), "citext", "nchar(115)")]
+    public void Returns_correct_mapping_for_prefixed_typed_ids(
+        Type idType,
+        string expectedPostgres,
+        string expectedSqlServer
+    )
+    {
+        AssertMapping(postgresPlugin, idType, expectedPostgres);
+        AssertMapping(sqlServerPlugin, idType, expectedSqlServer);
+    }
+
+    [Theory]
+    [InlineData(typeof(IntId), "integer", "int")]
+    [InlineData(typeof(LongId), "bigint", "bigint")]
+    [InlineData(typeof(GuidId), "uuid", "uniqueidentifier")]
+    public void Returns_correct_mapping_for_raw_typed_ids(
+        Type idType,
+        string expectedPostgres,
+        string expectedSqlServer
+    )
+    {
+        AssertMapping(postgresPlugin, idType, expectedPostgres);
+        AssertMapping(sqlServerPlugin, idType, expectedSqlServer);
+    }
+
+    [Theory]
+    [InlineData(typeof(StringId), "citext", "nvarchar(100)")]
+    public void Returns_correct_mapping_for_raw_string_typed_ids(
+        Type idType,
+        string expectedPostgres,
+        string expectedSqlServer
+    )
+    {
+        AssertMapping(postgresPlugin, idType, expectedPostgres);
+        AssertMapping(sqlServerPlugin, idType, expectedSqlServer);
+    }
+
+    [Fact]
+    public void Returns_null_for_non_typed_id_types()
+    {
+        var mappingInfo = new RelationalTypeMappingInfo(typeof(int));
+
+        Assert.Null(postgresPlugin.FindMapping(mappingInfo));
+        Assert.Null(sqlServerPlugin.FindMapping(mappingInfo));
+    }
+
+    [Fact]
+    public void Returns_null_for_null_type()
+    {
+        var mappingInfo = new RelationalTypeMappingInfo();
+
+        Assert.Null(postgresPlugin.FindMapping(mappingInfo));
+        Assert.Null(sqlServerPlugin.FindMapping(mappingInfo));
+    }
+
+    private static void AssertMapping(TypedIdTypeMappingSourcePlugin plugin, Type idType, string expectedStoreType)
+    {
+        var mappingInfo = new RelationalTypeMappingInfo(idType);
+        var mapping = plugin.FindMapping(mappingInfo);
+
+        Assert.NotNull(mapping);
+        Assert.Equal(idType, mapping.ClrType);
+        Assert.Equal(expectedStoreType, mapping.StoreType);
+    }
+}

--- a/test/LeanCode.IntegrationTests/App/TestDbContext.cs
+++ b/test/LeanCode.IntegrationTests/App/TestDbContext.cs
@@ -9,7 +9,6 @@ public class TestDbContext : DbContext
 {
     public DbSet<Entity> Entities => Set<Entity>();
     public DbSet<Meeting> Meetings => Set<Meeting>();
-    public DbSet<PushNotificationTokenEntity<Guid>> Tokens => Set<PushNotificationTokenEntity<Guid>>();
 
     public TestDbContext(DbContextOptions<TestDbContext> opts)
         : base(opts) { }
@@ -32,7 +31,7 @@ public class TestDbContext : DbContext
         modelBuilder.AddOutboxMessageEntity();
         modelBuilder.AddOutboxStateEntity();
 
-        modelBuilder.ConfigurePushNotificationTokenEntity<Guid>(setTokenColumnMaxLength: true);
+        modelBuilder.ConfigurePushNotificationTokenEntity<PNUserId>(setTokenColumnMaxLength: true);
     }
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
@@ -40,5 +39,6 @@ public class TestDbContext : DbContext
         base.ConfigureConventions(configurationBuilder);
         configurationBuilder.Properties<EntityId>().ArePrefixedTypedId();
         configurationBuilder.Properties<MeetingId>().ArePrefixedTypedId();
+        configurationBuilder.Properties<PNUserId>().AreGuidTypedId();
     }
 }

--- a/test/LeanCode.IntegrationTests/PushNotificationTokenStoreTests.cs
+++ b/test/LeanCode.IntegrationTests/PushNotificationTokenStoreTests.cs
@@ -1,3 +1,4 @@
+using LeanCode.DomainModels.Ids;
 using LeanCode.Firebase.FCM;
 using LeanCode.IntegrationTests.App;
 using LeanCode.Logging;
@@ -7,11 +8,14 @@ using Xunit;
 
 namespace LeanCode.IntegrationTests;
 
+[TypedId(TypedIdFormat.RawGuid)]
+public readonly partial record struct PNUserId;
+
 public class PushNotificationTokenStoreTests : IAsyncLifetime
 {
     private readonly TestApp app;
     private AsyncServiceScope scope;
-    private PushNotificationTokenStore<TestDbContext, Guid> store = default!;
+    private PushNotificationTokenStore<TestDbContext, PNUserId> store = default!;
 
     public PushNotificationTokenStoreTests()
     {
@@ -22,7 +26,7 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
     public async Task Gets_freshly_saved_token()
     {
         const string Token = "token";
-        var uid = Guid.NewGuid();
+        var uid = PNUserId.New();
 
         await store.AddUserTokenAsync(uid, Token);
         var result = await store.GetTokensAsync(uid);
@@ -35,7 +39,7 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
     {
         const string Token1 = "token1";
         const string Token2 = "token2";
-        var uid = Guid.NewGuid();
+        var uid = PNUserId.New();
 
         await store.AddUserTokenAsync(uid, Token1);
         await store.AddUserTokenAsync(uid, Token2);
@@ -49,13 +53,13 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
     {
         const string Token1 = "token1";
         const string Token2 = "token2";
-        var uid1 = Guid.NewGuid();
-        var uid2 = Guid.NewGuid();
+        var uid1 = PNUserId.New();
+        var uid2 = PNUserId.New();
 
         await store.AddUserTokenAsync(uid1, Token1);
         await store.AddUserTokenAsync(uid2, Token2);
 
-        var result = await store.GetTokensAsync(new HashSet<Guid> { uid1, uid2 });
+        var result = await store.GetTokensAsync(new HashSet<PNUserId> { uid1, uid2 });
 
         Assert.Equal(2, result.Count);
         var first = Assert.Single(result, e => e.Key == uid1);
@@ -72,7 +76,7 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
     {
         const string Token1 = "token1";
         const string Token2 = "token2";
-        var uid = Guid.NewGuid();
+        var uid = PNUserId.New();
 
         await store.AddUserTokenAsync(uid, Token1);
         await store.AddUserTokenAsync(uid, Token2);
@@ -87,8 +91,8 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
     {
         const string Token1 = "token1";
         const string Token2 = "token2";
-        var uid1 = Guid.NewGuid();
-        var uid2 = Guid.NewGuid();
+        var uid1 = PNUserId.New();
+        var uid2 = PNUserId.New();
 
         await store.AddUserTokenAsync(uid1, Token1);
         await store.AddUserTokenAsync(uid2, Token2);
@@ -108,8 +112,8 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
     {
         const string Token1 = "token1";
         const string Token2 = "token2";
-        var uid1 = Guid.NewGuid();
-        var uid2 = Guid.NewGuid();
+        var uid1 = PNUserId.New();
+        var uid2 = PNUserId.New();
 
         await store.AddUserTokenAsync(uid1, Token1);
         await store.AddUserTokenAsync(uid2, Token2);
@@ -128,7 +132,7 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
     {
         const string Token1 = "token1";
         const string Token2 = "token2";
-        var uid = Guid.NewGuid();
+        var uid = PNUserId.New();
 
         await store.AddUserTokenAsync(uid, Token1);
         await store.AddUserTokenAsync(uid, Token2);
@@ -147,7 +151,7 @@ public class PushNotificationTokenStoreTests : IAsyncLifetime
 
         store = new(
             scope.ServiceProvider.GetRequiredService<TestDbContext>(),
-            scope.ServiceProvider.GetRequiredService<ILogger<PushNotificationTokenStore<TestDbContext, Guid>>>()
+            scope.ServiceProvider.GetRequiredService<ILogger<PushNotificationTokenStore<TestDbContext, PNUserId>>>()
         );
     }
 

--- a/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
+++ b/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
@@ -1,5 +1,6 @@
 using LeanCode.DomainModels.EF;
 using LeanCode.IntegrationTestHelpers;
+using LeanCode.IntegrationTests.App;
 using MassTransit;
 using MassTransit.EntityFrameworkCoreIntegration;
 using Microsoft.EntityFrameworkCore;
@@ -35,7 +36,9 @@ public class SqlServerTestDatabaseConfig : TestDatabaseConfig
 
     public override void ConfigureDbContext(DbContextOptionsBuilder builder, IConfiguration config)
     {
-        builder.UseSqlServer(config.GetValue<string>("SqlServer:ConnectionString"));
+        builder
+            .UseSqlServer(config.GetValue<string>("SqlServer:ConnectionString"))
+            .AddAllTypedIdPlugins(typeof(TestDbContext).Assembly);
     }
 
     public override void ConfigureMassTransitOutbox(IEntityFrameworkOutboxConfigurator configurator)
@@ -51,7 +54,10 @@ public class PostgresTestConfig : TestDatabaseConfig
 
     public override void ConfigureDbContext(DbContextOptionsBuilder builder, IConfiguration config)
     {
-        builder.UseNpgsql(config.GetValue<string>("Postgres:ConnectionString")).AddTimestampTzExpressionInterceptor();
+        builder
+            .UseNpgsql(config.GetValue<string>("Postgres:ConnectionString"))
+            .AddTimestampTzExpressionInterceptor()
+            .AddAllTypedIdPlugins(typeof(TestDbContext).Assembly);
     }
 
     public override void ConfigureMassTransitOutbox(IEntityFrameworkOutboxConfigurator configurator)

--- a/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
+++ b/test/LeanCode.IntegrationTests/TestDatabaseConfig.cs
@@ -36,9 +36,7 @@ public class SqlServerTestDatabaseConfig : TestDatabaseConfig
 
     public override void ConfigureDbContext(DbContextOptionsBuilder builder, IConfiguration config)
     {
-        builder
-            .UseSqlServer(config.GetValue<string>("SqlServer:ConnectionString"))
-            .AddAllTypedIdPlugins(typeof(TestDbContext).Assembly);
+        builder.UseSqlServer(config.GetValue<string>("SqlServer:ConnectionString")).AddSqlServerTypedIdMappingPlugins();
     }
 
     public override void ConfigureMassTransitOutbox(IEntityFrameworkOutboxConfigurator configurator)
@@ -57,7 +55,7 @@ public class PostgresTestConfig : TestDatabaseConfig
         builder
             .UseNpgsql(config.GetValue<string>("Postgres:ConnectionString"))
             .AddTimestampTzExpressionInterceptor()
-            .AddAllTypedIdPlugins(typeof(TestDbContext).Assembly);
+            .AddPostgresTypedIdMappingPlugins();
     }
 
     public override void ConfigureMassTransitOutbox(IEntityFrameworkOutboxConfigurator configurator)

--- a/test/LeanCode.Test.Helpers/IntegrationFactAttribute.cs
+++ b/test/LeanCode.Test.Helpers/IntegrationFactAttribute.cs
@@ -15,7 +15,7 @@ public class IntegrationFactAttribute : FactAttribute, ITraitAttribute
     )
         : base(sourceFilePath, sourceLineNumber)
     {
-        Explicit = false;
+        Explicit = true;
     }
 
     public virtual IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() =>

--- a/test/LeanCode.Test.Helpers/IntegrationFactAttribute.cs
+++ b/test/LeanCode.Test.Helpers/IntegrationFactAttribute.cs
@@ -15,7 +15,7 @@ public class IntegrationFactAttribute : FactAttribute, ITraitAttribute
     )
         : base(sourceFilePath, sourceLineNumber)
     {
-        Explicit = true;
+        Explicit = false;
     }
 
     public virtual IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() =>


### PR DESCRIPTION
This will enable us to use typed ids in raw SQL queries. The mapping plugin, with some additional work can replace the conventions completely, though right now they coexist

Also added a helper for registering conventions for all typed ids in the assembly. 