### PR TITLE
Split source generated IDs parse implementation by providing format provider

### DIFF
--- a/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/PrefixedGuidIdSourceBuilder.cs
+++ b/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/PrefixedGuidIdSourceBuilder.cs
@@ -55,8 +55,10 @@ namespace {{data.Namespace}}
         public static bool IsValid([NotNullWhen(true)] string? v) => v is not null && IsValid(v.AsSpan());
         public static bool IsValid(ReadOnlySpan<char> v) => TryParse(v, null, out _);
 
+        public static {{data.TypeName}} Parse(string v) => Parse(v, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for Guid parsing.")]
-        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider)
         {
             ArgumentNullException.ThrowIfNull(v);
             if (TryParse(v.AsSpan(), provider, out var id))
@@ -88,8 +90,10 @@ namespace {{data.Namespace}}
             return TryParse(s.AsSpan(), provider, out result);
         }
 
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s) => Parse(s, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for Guid parsing.")]
-        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
             if (TryParse(s, provider, out var result))
             {
@@ -102,6 +106,9 @@ namespace {{data.Namespace}}
                 );
             }
         }
+
+        public static bool TryParse(ReadOnlySpan<char> s, out {{data.TypeName}} result)
+            => TryParse(s, null, out result);
 
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for Guid parsing.")]
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out {{data.TypeName}} result)

--- a/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/PrefixedStringIdSourceBuilder.cs
+++ b/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/PrefixedStringIdSourceBuilder.cs
@@ -62,8 +62,10 @@ namespace {{data.Namespace}}
         public static bool IsValid([NotNullWhen(true)] string? v) => v is not null && IsValid(v.AsSpan());
         public static bool IsValid(ReadOnlySpan<char> v) => TryParse(v, null, out _);
 
+        public static {{data.TypeName}} Parse(string v) => Parse(v, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for string format validation.")]
-        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider)
         {
             ArgumentNullException.ThrowIfNull(v);
             if (TryParse(v.AsSpan(), provider, out var result))
@@ -95,8 +97,10 @@ namespace {{data.Namespace}}
             return TryParse(s.AsSpan(), provider, out result);
         }
 
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s) => Parse(s, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for string format validation.")]
-        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
             if (TryParse(s, provider, out var result))
             {
@@ -109,6 +113,9 @@ namespace {{data.Namespace}}
                 );
             }
         }
+
+        public static bool TryParse(ReadOnlySpan<char> s, out {{data.TypeName}} result)
+            => TryParse(s, null, out result);
 
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for string format validation.")]
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out {{data.TypeName}} result)

--- a/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/PrefixedUlidIdSourceBuilder.cs
+++ b/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/PrefixedUlidIdSourceBuilder.cs
@@ -53,8 +53,10 @@ namespace {{data.Namespace}}
         public static bool IsValid([NotNullWhen(true)] string? v) => v is not null && IsValid(v.AsSpan());
         public static bool IsValid(ReadOnlySpan<char> v) => TryParse(v, null, out _);
 
+        public static {{data.TypeName}} Parse(string v) => Parse(v, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for Ulid parsing.")]
-        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider)
         {
             ArgumentNullException.ThrowIfNull(v);
             if (TryParse(v.AsSpan(), provider, out var result))
@@ -86,8 +88,10 @@ namespace {{data.Namespace}}
             return TryParse(s.AsSpan(), provider, out result);
         }
 
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s) => Parse(s, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for Ulid parsing.")]
-        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
             if (TryParse(s, provider, out var result))
             {
@@ -100,6 +104,9 @@ namespace {{data.Namespace}}
                 );
             }
         }
+
+        public static bool TryParse(ReadOnlySpan<char> s, out {{data.TypeName}} result)
+            => TryParse(s, null, out result);
 
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for Ulid parsing.")]
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out {{data.TypeName}} result)

--- a/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/RawIdSourceBuilder.cs
+++ b/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/RawIdSourceBuilder.cs
@@ -69,7 +69,9 @@ namespace {{data.Namespace}}
             }
         }
 
-        public static {{data.TypeName}} Parse(string s, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(string s) => Parse(s, null);
+
+        public static {{data.TypeName}} Parse(string s, IFormatProvider? provider)
         {
             ArgumentNullException.ThrowIfNull(s);
             if (TryParse(s.AsSpan(), provider, out var result))
@@ -95,7 +97,9 @@ namespace {{data.Namespace}}
             return TryParse(s.AsSpan(), provider, out result);
         }
 
-        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s) => Parse(s, null);
+
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
             if (TryParse(s, provider, out var result))
             {
@@ -106,6 +110,9 @@ namespace {{data.Namespace}}
                 throw new FormatException($"Unable to parse the span as {{data.TypeName}}.");
             }
         }
+
+        public static bool TryParse(ReadOnlySpan<char> s, out {{data.TypeName}} result)
+            => TryParse(s, null, out result);
 
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out {{data.TypeName}} result)
         {

--- a/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/RawStringIdSourceBuilder.cs
+++ b/src/Domain/LeanCode.DomainModels.Generators/SourceBuilders/RawStringIdSourceBuilder.cs
@@ -41,8 +41,10 @@ namespace {{data.Namespace}}
         public static bool IsValid([NotNullWhen(true)] string? v) => v is not null && IsValid(v.AsSpan());
         public static bool IsValid(ReadOnlySpan<char> v) => TryParse(v, null, out _);
 
+        public static {{data.TypeName}} Parse(string v) => Parse(v, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for string length validation.")]
-        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(string v, IFormatProvider? provider)
         {
             ArgumentNullException.ThrowIfNull(v);
             if (TryParse(v.AsSpan(), provider, out var result))
@@ -73,8 +75,10 @@ namespace {{data.Namespace}}
             return TryParse(s.AsSpan(), provider, out result);
         }
 
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s) => Parse(s, null);
+
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for string length validation.")]
-        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null)
+        public static {{data.TypeName}} Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
             if (TryParse(s, provider, out var result))
             {
@@ -87,6 +91,9 @@ namespace {{data.Namespace}}
                 );
             }
         }
+
+        public static bool TryParse(ReadOnlySpan<char> s, out {{data.TypeName}} result)
+            => TryParse(s, null, out result);
 
         [SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "IFormatProvider is ignored for string length validation.")]
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out {{data.TypeName}} result)


### PR DESCRIPTION
The `CA1305` warning still get triggered when corelib is being used even if we try to suppress it at the source generated IDs, so the only way to not to trigger it is to split the parse implementations. It has additional benefits of not needing to provide a format provider when using the `TryParse`. 