### PR TITLE
Fix ContextualLogger bypassing Serilog destructuring policies (v10)

### DIFF
--- a/src/Infrastructure/LeanCode.Logging/ContextualLogger.cs
+++ b/src/Infrastructure/LeanCode.Logging/ContextualLogger.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using Serilog;
 using Serilog.Events;
+using Serilog.Parsing;
 
 namespace LeanCode.Logging;
 
@@ -8,4 +10,11 @@ public class ContextualLogger<T>(ILogger logger) : ILogger<T>
     private readonly ILogger logger = logger.ForContext<T>();
 
     public void Write(LogEvent logEvent) => logger.Write(logEvent);
+
+    public bool BindMessageTemplate(
+        string messageTemplate,
+        object?[]? propertyValues,
+        [NotNullWhen(true)] out MessageTemplate? parsedTemplate,
+        [NotNullWhen(true)] out IEnumerable<LogEventProperty>? boundProperties
+    ) => logger.BindMessageTemplate(messageTemplate, propertyValues, out parsedTemplate, out boundProperties);
 }

--- a/src/Infrastructure/LeanCode.Logging/NullLogger.cs
+++ b/src/Infrastructure/LeanCode.Logging/NullLogger.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
 using Serilog.Events;
+using Serilog.Parsing;
 
 namespace LeanCode.Logging;
 
@@ -7,4 +9,16 @@ public class NullLogger<T> : ILogger<T>
     public static readonly NullLogger<T> Instance = new();
 
     public void Write(LogEvent logEvent) { }
+
+    public bool BindMessageTemplate(
+        string messageTemplate,
+        object?[]? propertyValues,
+        [NotNullWhen(true)] out MessageTemplate? parsedTemplate,
+        [NotNullWhen(true)] out IEnumerable<LogEventProperty>? boundProperties
+    )
+    {
+        parsedTemplate = null;
+        boundProperties = null;
+        return false;
+    }
 }

--- a/test/Infrastructure/LeanCode.Logging.Tests/ContextualLoggerDestructuringTests.cs
+++ b/test/Infrastructure/LeanCode.Logging.Tests/ContextualLoggerDestructuringTests.cs
@@ -1,0 +1,37 @@
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace LeanCode.Logging.Tests;
+
+public class ContextualLoggerDestructuringTests
+{
+    private sealed class DestructuringMarker { }
+
+    [Fact]
+    public void ContextualLogger_applies_configured_destructuring_policies_to_message_templates()
+    {
+        var sink = new SingleLogEventCapturerSink();
+
+        using var log = new LoggerConfiguration().Destructure.With<RightSanitizer>().WriteTo.Sink(sink).CreateLogger();
+
+        Logging.ILogger<DestructuringMarker> contextualLogger = new ContextualLogger<DestructuringMarker>(log);
+
+        contextualLogger.Information("{@Payload}", Payload.Workable);
+
+        Assert.NotNull(sink.LastEvent);
+        var prop = sink.LastEvent!.Properties["Payload"];
+        var rendered = prop.ToString();
+
+        Assert.Contains(BaseSanitizer<Payload>.Placeholder, rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("NOT PLACEHOLDER", rendered, StringComparison.Ordinal);
+    }
+
+    private sealed class SingleLogEventCapturerSink : ILogEventSink
+    {
+        public LogEvent LastEvent { get; private set; } = null!;
+
+        public void Emit(LogEvent logEvent) => LastEvent = logEvent;
+    }
+}


### PR DESCRIPTION
same as https://github.com/leancodepl/corelibrary/pull/873

## Summary

`ContextualLogger<T>` only implemented `Write(LogEvent)`. On Serilog 4.x, `Information`, `Warning`, and similar APIs are default interface methods on `Serilog.ILogger` that bind templates via an internal unconfigured logger, so registered `IDestructuringPolicy` instances (including `BaseSanitizer<T>`) were never applied. Message binding must use the same configured `Serilog.ILogger` instance that owns the pipeline (including sanitizers).

This change implements `BindMessageTemplate` on `ContextualLogger<T>` and forwards to the inner logger. `NullLogger<T>` implements `BindMessageTemplate` by returning `false` so binding does not use the default static implementation.

## Test plan

- Added `ContextualLoggerDestructuringTests`: configures a logger with `Destructure.With<RightSanitizer>()`, logs `{@Payload}` through `LeanCode.Logging.ILogger<T>` (`ContextualLogger`), and asserts the captured property reflects sanitization (placeholder present, raw secret string absent).

## Notes

- **NullLogger:** returning `false` from `BindMessageTemplate` avoids constructing log events from the default binding path; behavior remains a no-op for logging.

---

*Made with [Cursor](https://cursor.com).*
