### PR TITLE
Multi-target contracts projects (v10)

### DIFF
--- a/src/CQRS/LeanCode.CQRS.Annotations/LeanCode.CQRS.Annotations.csproj
+++ b/src/CQRS/LeanCode.CQRS.Annotations/LeanCode.CQRS.Annotations.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework />
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <ProjectReference
       Include="../../Tools/LeanCode.CodeAnalysis/LeanCode.CodeAnalysis.csproj"
       Condition="'$(MSBuildProjectName)' != 'LeanCode.CodeAnalysis'
-                                And '$(TargetFramework)' == 'net9.0'"
+                                And '$(TargetFramework)' != 'netstandard2.0'"
     >
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Analyzer</OutputItemType>

--- a/src/Infrastructure/LeanCode.ForceUpdate.Contracts/LeanCode.ForceUpdate.Contracts.csproj
+++ b/src/Infrastructure/LeanCode.ForceUpdate.Contracts/LeanCode.ForceUpdate.Contracts.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Nullable>annotations</Nullable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework />
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/LeanCode.ForceUpdate.Contracts/VersionSupport.cs
+++ b/src/Infrastructure/LeanCode.ForceUpdate.Contracts/VersionSupport.cs
@@ -1,7 +1,9 @@
 using LeanCode.Contracts;
+using LeanCode.Contracts.Security;
 
 namespace LeanCode.ForceUpdate.Contracts;
 
+[AllowUnauthorized]
 public class VersionSupport : IQuery<VersionSupportDTO>
 {
     public PlatformDTO Platform { get; set; }


### PR DESCRIPTION
Plus a minor fix to VersionSupport, see the commits. Allows one to stop depending on long-deprecated `net6.0` TFM.

I'll port this to v11 branch afterwards.